### PR TITLE
Using array_key_exists() on objects is deprecated

### DIFF
--- a/src/AbstractFactory/ConfigAbstractFactory.php
+++ b/src/AbstractFactory/ConfigAbstractFactory.php
@@ -22,10 +22,13 @@ final class ConfigAbstractFactory implements AbstractFactoryInterface
      */
     public function canCreate(\Interop\Container\ContainerInterface $container, $requestedName)
     {
-        if (! $container->has('config') || ! array_key_exists(self::class, $container->get('config'))) {
+        if (! $container->has('config')) {
             return false;
         }
         $config = $container->get('config');
+        if (! isset($config[self::class])) {
+            return false;
+        }
         $dependencies = $config[self::class];
 
         return is_array($dependencies) && array_key_exists($requestedName, $dependencies);
@@ -45,10 +48,10 @@ final class ConfigAbstractFactory implements AbstractFactoryInterface
         if (! (is_array($config) || $config instanceof ArrayObject)) {
             throw new ServiceNotCreatedException('Config must be an array or an instance of ArrayObject');
         }
-
-        if (! array_key_exists(self::class, $config)) {
+        if (! isset($config[self::class])) {
             throw new ServiceNotCreatedException('Cannot find a `' . self::class . '` key in the config array');
         }
+
 
         $dependencies = $config[self::class];
 


### PR DESCRIPTION
```
There were 2 errors:

1) LaminasTest\ServiceManager\AbstractFactory\ConfigAbstractFactoryTest::testCanCreateReturnsTrueWhenConfigIsAnArrayObject
array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

/dev/shm/BUILDROOT/php-laminas-servicemanager-3.4.0-1.fc31.remi.x86_64/usr/share/php/Laminas/ServiceManager/AbstractFactory/ConfigAbstractFactory.php:25
/dev/shm/BUILD/laminas-servicemanager-044cb8e380682563fb277ed5f6de4f690e4e6239/test/AbstractFactory/ConfigAbstractFactoryTest.php:95

2) LaminasTest\ServiceManager\AbstractFactory\ConfigAbstractFactoryTest::testFactoryCanCreateInstancesWhenConfigIsAnArrayObject
array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

/dev/shm/BUILDROOT/php-laminas-servicemanager-3.4.0-1.fc31.remi.x86_64/usr/share/php/Laminas/ServiceManager/AbstractFactory/ConfigAbstractFactory.php:49
/dev/shm/BUILD/laminas-servicemanager-044cb8e380682563fb277ed5f6de4f690e4e6239/test/AbstractFactory/ConfigAbstractFactoryTest.php:112

```