### PR TITLE
update exception messages

### DIFF
--- a/src/AbstractFactory/ConfigAbstractFactory.php
+++ b/src/AbstractFactory/ConfigAbstractFactory.php
@@ -56,14 +56,16 @@ final class ConfigAbstractFactory implements AbstractFactoryInterface
             || ! array_key_exists($requestedName, $dependencies)
             || ! is_array($dependencies[$requestedName])
         ) {
-            throw new ServiceNotCreatedException('Dependencies config must exist and be an array');
+            throw new ServiceNotCreatedException('Service dependencies config must exist and be an array');
         }
 
         $serviceDependencies = $dependencies[$requestedName];
 
         if ($serviceDependencies !== array_values(array_map('strval', $serviceDependencies))) {
             $problem = json_encode(array_map('gettype', $serviceDependencies));
-            throw new ServiceNotCreatedException('Service message must be an array of strings, ' . $problem . ' given');
+            throw new ServiceNotCreatedException(
+                'Service dependencies config must be an array of strings, ' . $problem . ' given'
+            );
         }
 
         $arguments = array_map([$container, 'get'], $serviceDependencies);

--- a/test/AbstractFactory/ConfigAbstractFactoryTest.php
+++ b/test/AbstractFactory/ConfigAbstractFactoryTest.php
@@ -224,7 +224,7 @@ class ConfigAbstractFactoryTest extends TestCase
             ]
         );
         self::expectException(ServiceNotCreatedException::class);
-        self::expectExceptionMessage('Dependencies config must exist and be an array');
+        self::expectExceptionMessage('Service dependencies config must exist and be an array');
 
         $abstractFactory($serviceManager, 'Dirk_Gently');
     }
@@ -240,7 +240,7 @@ class ConfigAbstractFactoryTest extends TestCase
             ]
         );
         self::expectException(ServiceNotCreatedException::class);
-        self::expectExceptionMessage('Dependencies config must exist and be an array');
+        self::expectExceptionMessage('Service dependencies config must exist and be an array');
 
         $abstractFactory($serviceManager, 'Dirk_Gently');
     }
@@ -258,7 +258,7 @@ class ConfigAbstractFactoryTest extends TestCase
             ]
         );
         self::expectException(ServiceNotCreatedException::class);
-        self::expectExceptionMessage('Dependencies config must exist and be an array');
+        self::expectExceptionMessage('Service dependencies config must exist and be an array');
 
         $abstractFactory($serviceManager, 'Dirk_Gently');
     }
@@ -282,7 +282,7 @@ class ConfigAbstractFactoryTest extends TestCase
         );
         self::expectException(ServiceNotCreatedException::class);
         self::expectExceptionMessage(
-            'Service message must be an array of strings, ["string","string","string","integer"] given'
+            'Service dependencies config must be an array of strings, ["string","string","string","integer"] given'
         );
 
         $abstractFactory($serviceManager, 'DirkGently');


### PR DESCRIPTION
Just txt changes to have clearer messages. Not sure that in ConfigAbstractFactory `Service messages` was a typo and intended to be "Service dependencies".

There are 2 unrelated cs warnings: https://travis-ci.org/github/pine3ree/laminas-servicemanager/builds/676703964, the first can be fixed, the second causes problems with the FactoryCreatorCommand.