### PR TITLE
Fixing travis build : ignore cs check on SimpleDependencyObjectFactory test asset

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,4 +9,5 @@
     <file>benchmarks</file>
 
     <exclude-pattern>test/log/</exclude-pattern>
+    <exclude-pattern>test/TestAsset/factories/SimpleDependencyObject.php</exclude-pattern>
 </ruleset>

--- a/test/TestAsset/factories/SimpleDependencyObject.php
+++ b/test/TestAsset/factories/SimpleDependencyObject.php
@@ -4,7 +4,6 @@ namespace LaminasTest\ServiceManager\TestAsset;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use LaminasTest\ServiceManager\TestAsset\InvokableObject;
 use LaminasTest\ServiceManager\TestAsset\SimpleDependencyObject;
 
 class SimpleDependencyObjectFactory implements FactoryInterface
@@ -17,6 +16,6 @@ class SimpleDependencyObjectFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        return new SimpleDependencyObject($container->get(InvokableObject::class));
+        return new SimpleDependencyObject($container->get(\LaminasTest\ServiceManager\TestAsset\InvokableObject::class));
     }
 }


### PR DESCRIPTION
The `SimpleDependencyObjectFactory` test asset can be ignored from php cs.

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
