### PR TITLE
Alphabetize import statements in generated factories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ matrix:
         - DEPS=latest
     - php: 7.3
       env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
         - DEPS=latest
     - php: 7.4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,18 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#40](https://github.com/laminas/laminas-servicemanager/pull/40) modifies the behavior of the `FactoryCreator` to alphabetize import statements.
+
 - [zendframework/zend-servicemanager#221](https://github.com/zendframework/zend-servicemanager/pull/221) provides enormous performance improvements for each of the various mutator methods (`setAlias()`, `setFactory()`, etc.), `has()` lookups, and initial container configuration.
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "mikey179/vfsstream": "^1.6.4",
         "ocramius/proxy-manager": "^2.1.1",
         "phpbench/phpbench": "^0.13.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.5.20"
     },
     "provide": {
         "psr/container-implementation": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "mikey179/vfsstream": "^1.6.4",
         "ocramius/proxy-manager": "^2.1.1",
         "phpbench/phpbench": "^0.13.0",
-        "phpunit/phpunit": "^6.4.4"
+        "phpunit/phpunit": "^7.0"
     },
     "provide": {
         "psr/container-implementation": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-container-config-test": "^0.2.1",
-        "mikey179/vfsstream": "^1.6.4",
+        "mikey179/vfsstream": "^1.6.8",
         "ocramius/proxy-manager": "^2.1.1",
         "phpbench/phpbench": "^0.13.0",
         "phpunit/phpunit": "^7.5.20"

--- a/test/TestAsset/factories/ComplexDependencyObject.php
+++ b/test/TestAsset/factories/ComplexDependencyObject.php
@@ -2,8 +2,8 @@
 
 namespace LaminasTest\ServiceManager\TestAsset;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use LaminasTest\ServiceManager\TestAsset\ComplexDependencyObject;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class ComplexDependencyObjectFactory implements FactoryInterface

--- a/test/TestAsset/factories/InvokableObject.php
+++ b/test/TestAsset/factories/InvokableObject.php
@@ -2,8 +2,8 @@
 
 namespace LaminasTest\ServiceManager\TestAsset;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use LaminasTest\ServiceManager\TestAsset\InvokableObject;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class InvokableObjectFactory implements FactoryInterface

--- a/test/TestAsset/factories/SimpleDependencyObject.php
+++ b/test/TestAsset/factories/SimpleDependencyObject.php
@@ -2,8 +2,8 @@
 
 namespace LaminasTest\ServiceManager\TestAsset;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use LaminasTest\ServiceManager\TestAsset\SimpleDependencyObject;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class SimpleDependencyObjectFactory implements FactoryInterface


### PR DESCRIPTION
Previously, the imports were _mostly_ alphabetized. However, with the switch to Laminas, the container import was now happening incorrectly with regards to the factory interface, causing test failures when doing comparisons between expected results and actual results. Additionally, it makes sense to alphabetize to ensure we follow our own CS.

This patch updates the factory generation code to alphabetize import statements before injecting them in the template.

The work is done on the develop branch as that was the branch exhibiting the test failure behaviors.