### PR TITLE
#6 Bump supported PHP version to 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,30 +12,21 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=latest
         - CS_CHECK=true
         - BENCHMARKS=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
-        - DEPS=latest
-    - php: 7.4
-      env:
         - DEPS=lowest
     - php: 7.4
       env:
-        - DEPS=latest
+        - DEPS=lowest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env:
         - DEPS=lowest
     - php: 7.4
-        env:
+      env:
         - DEPS=latest
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - php: 7.4
       env:
         - DEPS=lowest
+    - php: 7.4
+        env:
+          - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - DEPS=lowest
     - php: 7.4
         env:
-          - DEPS=latest
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,15 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - BENCHMARKS=true
         - TEST_COVERAGE=true
-    - php: 7.3
-      env:
-        - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "psr/container-implementation": "^1.0"
     },
     "conflict": {
-        "container-interop/container-interop": "<1.2.0"
+        "container-interop/container-interop": "<1.2.0",
+        "zendframework/zend-code": "<3.3.1"
     },
     "suggest": {
         "laminas/laminas-stdlib": "laminas-stdlib ^2.7.7 | ^3.1 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/container": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/container": "^1.0"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Updated minimum PHP versions and supported versions in Composer and Travis.

Fixes #6