### PR TITLE
Psalm support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,9 @@
         "ocramius/proxy-manager": "^2.2.3",
         "phpbench/phpbench": "^1.0.0-alpha3",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.4"
+        "phpunit/phpunit": "^9.4",
+        "psalm/plugin-phpunit": "^0.15.0",
+        "vimeo/psalm": "^4.3.1"
     },
     "provide": {
         "container-interop/container-interop-implementation": "^1.2",
@@ -76,7 +78,8 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "static-analysis" : "psalm --shepherd --stats"
     },
     "replace": {
         "zendframework/zend-servicemanager": "^3.4.0"

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "phpbench/phpbench": "^1.0.0-alpha3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4",
-        "psalm/plugin-phpunit": "^0.15.0",
-        "vimeo/psalm": "^4.3.1"
+        "psalm/plugin-phpunit": "^0.16.1",
+        "vimeo/psalm": "^4.8"
     },
     "provide": {
         "container-interop/container-interop-implementation": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b233d16abae06fedff5728ee17547a30",
+    "content-hash": "dbe3c01e2deb156bd0e0462b145a566e",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -144,27 +144,22 @@
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -177,7 +172,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -189,10 +184,180 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-16T20:06:06+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
         {
             "name": "beberlei/assert",
             "version": "v3.3.0",
@@ -256,16 +421,16 @@
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.1",
+            "version": "1.11.99.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
                 "shasum": ""
             },
             "require": {
@@ -307,6 +472,10 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -321,7 +490,189 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-11T10:22:58+00:00"
+            "time": "2021-05-24T07:46:03+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T12:41:47+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-05T19:37:51+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -534,6 +885,107 @@
                 }
             ],
             "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -901,17 +1353,68 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "name": "netresearch/jsonmapper",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+            },
+            "time": "2020-12-01T19:48:11+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +1453,11 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-12-20T10:01:03+00:00"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+            },
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -1021,6 +1528,59 @@
                 "service proxies"
             ],
             "time": "2019-08-10T08:37:15+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1341,6 +1901,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -1393,6 +1957,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
             "time": "2020-09-03T19:13:55+00:00"
         },
         {
@@ -1438,6 +2006,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
@@ -1949,6 +2521,116 @@
             "time": "2021-02-02T14:45:58+00:00"
         },
         {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.16.1"
+            },
+            "time": "2021-06-18T23:56:46+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "1.0.1",
             "source": {
@@ -2280,6 +2962,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2987,20 +3673,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.3",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
@@ -3063,6 +3750,9 @@
                 "console",
                 "terminal"
             ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.3.2"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3077,20 +3767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-06-12T09:42:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
                 "shasum": ""
             },
             "require": {
@@ -3099,7 +3789,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3127,6 +3817,9 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3141,7 +3834,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3328,16 +4021,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -3349,7 +4042,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3386,6 +4079,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3400,20 +4096,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
                 "shasum": ""
             },
             "require": {
@@ -3425,7 +4121,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3464,6 +4160,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3478,20 +4177,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -3503,7 +4202,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3545,6 +4244,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3559,20 +4261,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T17:09:11+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
                 "shasum": ""
             },
             "require": {
@@ -3584,7 +4286,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3622,6 +4324,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3636,20 +4341,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -3658,7 +4363,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3698,6 +4403,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3712,20 +4420,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
                 "shasum": ""
             },
             "require": {
@@ -3734,7 +4442,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3778,6 +4486,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3792,7 +4503,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/process",
@@ -3855,21 +4566,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -3877,7 +4588,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3913,6 +4624,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3927,20 +4641,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-04-01T10:43:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.3",
+            "version": "v5.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
                 "shasum": ""
             },
             "require": {
@@ -3993,6 +4707,9 @@
                 "utf-8",
                 "utf8"
             ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.3"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4007,7 +4724,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-25T15:14:59+00:00"
+            "time": "2021-06-27T11:44:38+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4056,31 +4773,141 @@
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
+            "name": "vimeo/psalm",
+            "version": "4.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f73f2299dbc59a3e6c4d66cff4605176e728ee69",
+                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.5",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3 || ^5.0",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.8.1"
+            },
+            "time": "2021-06-20T23:03:20+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -4102,7 +4929,11 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -4148,6 +4979,10 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
@@ -4162,5 +4997,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,1523 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
+  <file src="src/AbstractFactory/ConfigAbstractFactory.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $requestedName(...$arguments)</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="2">
+      <code>$serviceDependencies</code>
+      <code>$serviceDependencies</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config[self::class]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$dependencies</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/AbstractFactory/ReflectionBasedAbstractFactory.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$requestedName</code>
+      <code>$requestedName</code>
+    </ArgumentTypeCoercion>
+    <InvalidStringClass occurrences="3">
+      <code>new $requestedName()</code>
+      <code>new $requestedName()</code>
+      <code>new $requestedName(...$parameters)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="3">
+      <code>new $requestedName()</code>
+      <code>new $requestedName()</code>
+      <code>new $requestedName(...$parameters)</code>
+    </LessSpecificReturnStatement>
+    <MissingClosureReturnType occurrences="2">
+      <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
+      <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
+    </MissingClosureReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>DispatchableInterface</code>
+    </MoreSpecificReturnType>
+    <RedundantCondition occurrences="1">
+      <code>is_string($type)</code>
+    </RedundantCondition>
+    <UndefinedDocblockClass occurrences="1">
+      <code>DispatchableInterface</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/AbstractFactoryInterface.php">
+    <MissingParamType occurrences="4">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$requestedName</code>
+      <code>$requestedName</code>
+    </MissingParamType>
+  </file>
+  <file src="src/AbstractPluginManager.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>gettype($instance)</code>
+    </DocblockTypeContradiction>
+    <MissingParamType occurrences="1">
+      <code>$instance</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>setService</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="3">
+      <code>$instance</code>
+      <code>$service</code>
+      <code>$this-&gt;instanceOf</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$instance</code>
+      <code>$service</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$name</code>
+    </ParamNameMismatch>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$service</code>
+    </PossiblyInvalidArgument>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($instance)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Config.php">
+    <MissingReturnType occurrences="1">
+      <code>merge</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="7">
+      <code>$a[$key]</code>
+      <code>$a[$key]</code>
+      <code>$a[$key]</code>
+      <code>$a[$key]</code>
+      <code>$a[]</code>
+      <code>$this-&gt;config</code>
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Exception/CyclicAliasException.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>self::deDuplicateDetectedCycles($detectedCycles)</code>
+    </InvalidScalarArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$alias</code>
+      <code>$detectedCycles</code>
+    </MixedArgumentTypeCoercion>
+    <PossiblyFalseOperand occurrences="1">
+      <code>$cycle</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="src/Factory/DelegatorFactoryInterface.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>ContainerException</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Factory/FactoryInterface.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>ContainerException</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Factory/InvokableFactory.php">
+    <InvalidStringClass occurrences="2">
+      <code>new $requestedName</code>
+      <code>new $requestedName($options)</code>
+    </InvalidStringClass>
+  </file>
+  <file src="src/InitializerInterface.php">
+    <MissingParamType occurrences="1">
+      <code>$instance</code>
+    </MissingParamType>
+  </file>
+  <file src="src/PluginManagerInterface.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>ContainerException</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Proxy/LazyServiceFactory.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;servicesMap[$name]</code>
+    </ArgumentTypeCoercion>
+    <MissingClosureParamType occurrences="1">
+      <code>$wrappedInstance</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function (&amp;$wrappedInstance, LazyLoadingInterface $proxy) use ($callback) {</code>
+    </MissingClosureReturnType>
+    <MixedAssignment occurrences="1">
+      <code>$wrappedInstance</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/ServiceLocatorInterface.php">
+    <InvalidThrow occurrences="1">
+      <code>ContainerExceptionInterface</code>
+    </InvalidThrow>
+  </file>
+  <file src="src/ServiceManager.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($delegatorFactory)</code>
+    </DocblockTypeContradiction>
+    <InvalidCatch occurrences="1"/>
+    <InvalidDocblockParamName occurrences="1">
+      <code>$abstractFactories</code>
+    </InvalidDocblockParamName>
+    <InvalidThrow occurrences="1">
+      <code>ExceptionInterface</code>
+    </InvalidThrow>
+    <MissingClosureReturnType occurrences="2">
+      <code>function () use ($delegatorFactory, $name, $creationCallback, $options) {</code>
+      <code>function () use ($name, $options) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="1">
+      <code>$abstractFactory</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$allowOverride</code>
+      <code>$this-&gt;allowOverride</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="15">
+      <code>addAbstractFactory</code>
+      <code>addDelegator</code>
+      <code>addInitializer</code>
+      <code>createAliasesAndFactoriesForInvokables</code>
+      <code>mapAliasToTarget</code>
+      <code>mapAliasesToTargets</code>
+      <code>mapLazyService</code>
+      <code>resolveInitializers</code>
+      <code>setAlias</code>
+      <code>setAllowOverride</code>
+      <code>setFactory</code>
+      <code>setInvokableClass</code>
+      <code>setService</code>
+      <code>setShared</code>
+      <code>validateServiceNames</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="20">
+      <code>$alias</code>
+      <code>$alias</code>
+      <code>$alias</code>
+      <code>$config['delegators']</code>
+      <code>$config['initializers']</code>
+      <code>$config['invokables']</code>
+      <code>$config['lazy_services']</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;lazyServices['class_map']</code>
+      <code>$this-&gt;lazyServices['proxies_namespace']</code>
+      <code>$this-&gt;lazyServices['proxies_target_dir']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="5">
+      <code>$alias</code>
+      <code>$alias</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$this-&gt;aliases[$alias]</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="3">
+      <code>$this-&gt;aliases[$alias]</code>
+      <code>$this-&gt;aliases[$name]</code>
+      <code>$this-&gt;factories[$class]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="15">
+      <code>$tagged[$aCursor]</code>
+      <code>$tagged[$alias]</code>
+      <code>$tagged[$alias]</code>
+      <code>$this-&gt;aliases[$alias]</code>
+      <code>$this-&gt;aliases[$alias]</code>
+      <code>$this-&gt;aliases[$tCursor]</code>
+      <code>$this-&gt;aliases[$tCursor]</code>
+      <code>$this-&gt;factories[$class]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+      <code>$this-&gt;services[$service]</code>
+    </MixedArrayOffset>
+    <MixedArrayTypeCoercion occurrences="2">
+      <code>$this-&gt;aliases[$tCursor]</code>
+      <code>$this-&gt;aliases[$tCursor]</code>
+    </MixedArrayTypeCoercion>
+    <MixedAssignment occurrences="31">
+      <code>$aCursor</code>
+      <code>$aCursor</code>
+      <code>$abstractFactories</code>
+      <code>$abstractFactory</code>
+      <code>$abstractFactory</code>
+      <code>$alias</code>
+      <code>$alias</code>
+      <code>$class</code>
+      <code>$key</code>
+      <code>$object</code>
+      <code>$object</code>
+      <code>$object</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$stack[]</code>
+      <code>$tCursor</code>
+      <code>$tCursor</code>
+      <code>$target</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;factories</code>
+      <code>$this-&gt;factories</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;shared</code>
+      <code>$this-&gt;sharedByDefault</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>bool</code>
+      <code>object</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="4">
+      <code>new $abstractFactory()</code>
+      <code>new $delegatorFactory()</code>
+      <code>new $factory()</code>
+      <code>new $initializer()</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="4">
+      <code>$config['aliases']</code>
+      <code>$config['factories']</code>
+      <code>$config['services']</code>
+      <code>$config['shared']</code>
+    </MixedOperand>
+    <MixedPropertyTypeCoercion occurrences="2">
+      <code>$this-&gt;aliases</code>
+      <code>$this-&gt;aliases</code>
+    </MixedPropertyTypeCoercion>
+    <MixedReturnStatement occurrences="2">
+      <code>$creationCallback($this-&gt;creationContext, $name, $creationCallback, $options)</code>
+      <code>$this-&gt;allowOverride</code>
+    </MixedReturnStatement>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;delegators</code>
+    </PropertyTypeCoercion>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(bool) $flag</code>
+      <code>(bool) $flag</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantCondition occurrences="7">
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+      <code>isset($this-&gt;services[$service]) &amp;&amp; ! $this-&gt;allowOverride</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($delegatorFactory)</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="1">
+      <code>$creationCallback($this-&gt;creationContext, $name, $creationCallback, $options)</code>
+    </TooManyArguments>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$sharedAlias</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Test/CommonPluginManagerTrait.php">
+    <MissingParamType occurrences="2">
+      <code>$alias</code>
+      <code>$expected</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="7">
+      <code>aliasProvider</code>
+      <code>getServiceNotFoundException</code>
+      <code>testInstanceOfMatches</code>
+      <code>testLoadingInvalidElementRaisesException</code>
+      <code>testPluginAliasesResolve</code>
+      <code>testRegisteringInvalidElementRaisesException</code>
+      <code>testShareByDefaultAndSharedByDefault</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$alias</code>
+      <code>$expected</code>
+      <code>$this-&gt;getServiceNotFoundException()</code>
+      <code>$this-&gt;getServiceNotFoundException()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
+      <code>$alias</code>
+      <code>$expected</code>
+      <code>$shareByDefault</code>
+      <code>$sharedByDefault</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Tool/ConfigDumper.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1">
+      <code>$value</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="1">
+      <code>$className</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>validateClassName</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$config['service_manager']</code>
+      <code>$config['service_manager']['factories']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAssignment occurrences="3">
+      <code>$config['service_manager']['factories']</code>
+      <code>$config[ConfigAbstractFactory::class][$className]</code>
+      <code>$config[ConfigAbstractFactory::class][$className]</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="2">
+      <code>$dependency</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <PossiblyNullArgument occurrences="1">
+      <code>$key</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$container</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="1">
+      <code>getParameters</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;container</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Tool/ConfigDumperCommand.php">
+    <MixedArgument occurrences="14">
+      <code>$arguments-&gt;class</code>
+      <code>$arguments-&gt;class</code>
+      <code>$arguments-&gt;config</code>
+      <code>$arguments-&gt;configFile</code>
+      <code>$arguments-&gt;configFile</code>
+      <code>$arguments-&gt;ignoreUnresolved</code>
+      <code>$arguments-&gt;message</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$configFile</code>
+      <code>$configFile</code>
+      <code>$configFile</code>
+      <code>$configFile</code>
+      <code>$configFile</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$arg1</code>
+      <code>$arg1</code>
+      <code>$configFile</code>
+    </MixedAssignment>
+    <RedundantCondition occurrences="1">
+      <code>false</code>
+    </RedundantCondition>
+  </file>
+  <file src="src/Tool/FactoryCreator.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </ArgumentTypeCoercion>
+    <MissingParamType occurrences="1">
+      <code>$className</code>
+    </MissingParamType>
+    <MixedArgument occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$dependency</code>
+    </MixedArgument>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($className, '\\')</code>
+    </PossiblyFalseOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getParameters</code>
+    </PossiblyNullReference>
+    <TypeDoesNotContainType occurrences="1">
+      <code>! $reflectionClass</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Tool/FactoryCreatorCommand.php">
+    <MixedArgument occurrences="5">
+      <code>$arguments-&gt;class</code>
+      <code>$arguments-&gt;class</code>
+      <code>$arguments-&gt;message</code>
+      <code>$class</code>
+      <code>$class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$arg1</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/AbstractFactory/ConfigAbstractFactoryTest.php">
+    <InvalidArgument occurrences="1">
+      <code>'Holistic'</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="14">
+      <code>testCanCreate</code>
+      <code>testCanCreateReturnsTrueIfDependencyNotArrays</code>
+      <code>testCanCreateReturnsTrueWhenConfigIsAnArrayObject</code>
+      <code>testExceptsWhenConfigIsNotArray</code>
+      <code>testExceptsWhenConfigKeyNotSet</code>
+      <code>testExceptsWhenConfigNotSet</code>
+      <code>testExceptsWhenServiceConfigDoesNotExist</code>
+      <code>testExceptsWhenServiceConfigForRequestedNameIsNotArray</code>
+      <code>testExceptsWhenServiceConfigForRequestedNameIsNotArrayOfStrings</code>
+      <code>testExceptsWhenServiceConfigIsNotArray</code>
+      <code>testFactoryCanCreateInstancesWhenConfigIsAnArrayObject</code>
+      <code>testInvokeWithComplexArguments</code>
+      <code>testInvokeWithInvokableClass</code>
+      <code>testInvokeWithSimpleArguments</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php">
+    <DocblockTypeContradiction occurrences="8">
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </DocblockTypeContradiction>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$instance-&gt;foo</code>
+      <code>$instance-&gt;value</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="12">
+      <code>nonClassRequestedNames</code>
+      <code>testCanCreateReturnsFalseForNonClassRequestedNames</code>
+      <code>testFactoryCanInjectKnownTypeHintedServices</code>
+      <code>testFactoryCanSupplyAMixOfParameterTypes</code>
+      <code>testFactoryInjectsConfigServiceForConfigArgumentsTypeHintedAsArray</code>
+      <code>testFactoryInstantiatesClassDirectlyIfConstructorHasNoArguments</code>
+      <code>testFactoryInstantiatesClassDirectlyIfItHasNoConstructor</code>
+      <code>testFactoryRaisesExceptionForScalarParameters</code>
+      <code>testFactoryRaisesExceptionWhenUnableToResolveATypeHintedService</code>
+      <code>testFactoryResolvesTypeHintsForServicesToWellKnownServiceNames</code>
+      <code>testFactoryWillUseDefaultValueForTypeHintedArgument</code>
+      <code>testFactoryWillUseDefaultValueWhenPresentForScalarArgument</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="16">
+      <code>$requestedName</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>SampleInterface::class</code>
+      <code>\LaminasTest\ServiceManager\AbstractFactory\ArrayAccess::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="6">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="15">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="13">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="2">
+      <code>SampleInterface</code>
+      <code>\LaminasTest\ServiceManager\AbstractFactory\ArrayAccess</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/AbstractFactory/TestAsset/ClassWithScalarDependencyDefiningDefaultValue.php">
+    <MissingPropertyType occurrences="1">
+      <code>$foo</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/AbstractFactory/TestAsset/ClassWithScalarParameters.php">
+    <MissingParamType occurrences="2">
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/AbstractFactory/TestAsset/ClassWithTypehintedDefaultValue.php">
+    <MissingPropertyType occurrences="1">
+      <code>$value</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/AbstractPluginManagerTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setServiceLocator</code>
+    </DeprecatedMethod>
+    <MissingClosureParamType occurrences="16">
+      <code>$callback</code>
+      <code>$container</code>
+      <code>$errmsg</code>
+      <code>$errno</code>
+      <code>$errno</code>
+      <code>$errno</code>
+      <code>$errno</code>
+      <code>$errno</code>
+      <code>$errno</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$name</code>
+      <code>$plugin</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>function ($container, $name, $callback) {</code>
+      <code>function ($plugin) use ($instance, &amp;$assertionCalled) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="2">
+      <code>$arg</code>
+      <code>$shareByDefault</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="22">
+      <code>createContainer</code>
+      <code>invalidConstructorArguments</code>
+      <code>shareByDefaultSettings</code>
+      <code>testAbstractFactoryGetsCreationContext</code>
+      <code>testAliasPropertyResolves</code>
+      <code>testAutoInvokableServicesAreNotKnownBeforeRetrieval</code>
+      <code>testCachesInstanceByDefaultIfNoOptionsArePassed</code>
+      <code>testCallingSetServiceLocatorSetsCreationContextWithDeprecationNotice</code>
+      <code>testCanPassConfigInterfaceAsFirstConstructorArgumentWithDeprecationNotice</code>
+      <code>testCanWrapCreationInDelegators</code>
+      <code>testGetRaisesExceptionWhenNoFactoryIsResolved</code>
+      <code>testInjectCreationContextInFactories</code>
+      <code>testPassingConfigInstanceAsFirstConstructorArgumentSkipsSecondArgumentWithDeprecationNotice</code>
+      <code>testPassingNoInitialConstructorArgumentSetsPluginManagerAsCreationContextWithDeprecationNotice</code>
+      <code>testPassingNonContainerNonConfigNonNullFirstConstructorArgumentRaisesException</code>
+      <code>testPassingServiceInstanceViaConfigureShouldRaiseExceptionForInvalidPlugin</code>
+      <code>testPluginManagersMayOptOutOfSupportingAutoInvokableServices</code>
+      <code>testReturnsDiscreteInstancesIfOptionsAreProvidedRegardlessOfShareByDefaultSetting</code>
+      <code>testSetServiceShouldRaiseExceptionForInvalidPlugin</code>
+      <code>testSupportsRetrievingAutoInvokableServicesByDefault</code>
+      <code>testValidateInstance</code>
+      <code>testValidateWillFallBackToValidatePluginWhenDefinedAndEmitDeprecationNotice</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="3">
+      <code>$arg</code>
+      <code>$errmsg</code>
+      <code>$pluginManager</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="6"/>
+    <MixedAssignment occurrences="3">
+      <code>$instance</code>
+      <code>$instance</code>
+      <code>$pluginManager</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$callback()</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="1">
+      <code>get</code>
+    </MixedMethodCall>
+    <MixedPropertyAssignment occurrences="1">
+      <code>$instance</code>
+    </MixedPropertyAssignment>
+    <MixedPropertyFetch occurrences="2">
+      <code>$instance-&gt;foo</code>
+      <code>$instance-&gt;option</code>
+    </MixedPropertyFetch>
+  </file>
+  <file src="test/CommonServiceLocatorBehaviorsTrait.php">
+    <InvalidArgument occurrences="1">
+      <code>ContainerExceptionInterface::class</code>
+    </InvalidArgument>
+    <InvalidArrayOffset occurrences="1">
+      <code>$config['shared']</code>
+    </InvalidArrayOffset>
+    <MissingClosureParamType occurrences="15">
+      <code>$callback</code>
+      <code>$callback</code>
+      <code>$className</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$errno</code>
+      <code>$errstr</code>
+      <code>$instance</code>
+      <code>$instance</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$requestedName</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="3">
+      <code>function ($container, $name, $callback) {</code>
+      <code>function ($container, $name, $callback) {</code>
+      <code>function ($container, $requestedName, array $options = null) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="11">
+      <code>$abstractFactory</code>
+      <code>$args</code>
+      <code>$container</code>
+      <code>$contains</code>
+      <code>$contains</code>
+      <code>$contains</code>
+      <code>$delegator</code>
+      <code>$expected</code>
+      <code>$factory</code>
+      <code>$initializer</code>
+      <code>$method</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$creationContext</code>
+      <code>$this-&gt;creationContext</code>
+      <code>$this-&gt;creationContext</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="52">
+      <code>abstractFactories</code>
+      <code>invalidAbstractFactories</code>
+      <code>invalidDelegators</code>
+      <code>invalidFactories</code>
+      <code>invalidInitializers</code>
+      <code>methodsAffectedByOverrideSettings</code>
+      <code>provideConsistencyOverInternalStatesTests</code>
+      <code>testAllowOverrideFlagIsFalseByDefault</code>
+      <code>testAllowOverrideFlagIsMutable</code>
+      <code>testAllowsMultipleInstancesOfTheSameAbstractFactory</code>
+      <code>testBuildNeverSharesInstances</code>
+      <code>testCanBuildObjectWithInvokableFactory</code>
+      <code>testCanConfigureAllServiceTypes</code>
+      <code>testCanCreateObjectWithClosureFactory</code>
+      <code>testCanCreateServiceWithAbstractFactory</code>
+      <code>testCanCreateServiceWithAlias</code>
+      <code>testCanDisableSharedByDefault</code>
+      <code>testCanDisableSharedForSingleService</code>
+      <code>testCanEnableSharedForSingleService</code>
+      <code>testCanInjectAbstractFactories</code>
+      <code>testCanInjectAliases</code>
+      <code>testCanInjectDelegators</code>
+      <code>testCanInjectFactories</code>
+      <code>testCanInjectInitializers</code>
+      <code>testCanInjectInvokables</code>
+      <code>testCanInjectServices</code>
+      <code>testCanInjectSharingRules</code>
+      <code>testCanMapLazyServices</code>
+      <code>testCanRetrieveParentContainerViaGetServiceLocatorWithDeprecationNotice</code>
+      <code>testCanSpecifyAbstractFactoryUsingStringViaConfiguration</code>
+      <code>testCanSpecifyInitializerUsingStringViaConfiguration</code>
+      <code>testCheckingServiceExistenceWithChecksAgainstAbstractFactories</code>
+      <code>testConfigureCanAddNewServices</code>
+      <code>testConfigureCanOverridePreviousSettings</code>
+      <code>testConfiguringInstanceRaisesExceptionIfAllowOverrideIsFalse</code>
+      <code>testConsistencyOverInternalStates</code>
+      <code>testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions</code>
+      <code>testCrashesOnCyclicAliases</code>
+      <code>testGetRaisesExceptionWhenNoFactoryIsResolved</code>
+      <code>testHasChecksAgainstAbstractFactories</code>
+      <code>testHasReturnsFalseIfServiceNotConfigured</code>
+      <code>testHasReturnsTrueIfFactoryIsConfigured</code>
+      <code>testHasReturnsTrueIfServiceIsConfigured</code>
+      <code>testInitializersAreRunAfterCreation</code>
+      <code>testInvalidDelegatorShouldRaiseExceptionDuringCreation</code>
+      <code>testIsSharedByDefault</code>
+      <code>testMinimalCyclicAliasDefinitionShouldThrow</code>
+      <code>testPassingInvalidAbstractFactoryTypeViaConfigurationRaisesException</code>
+      <code>testPassingInvalidInitializerTypeViaConfigurationRaisesException</code>
+      <code>testThrowExceptionIfServiceCannotBeCreated</code>
+      <code>testThrowExceptionWithStringAsCodeIfServiceCannotBeCreated</code>
+      <code>testWillReUseAnExistingNamedAbstractFactoryInstance</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="6">
+      <code>$container</code>
+      <code>$contains</code>
+      <code>$contains</code>
+      <code>$contains</code>
+      <code>$lazyServices</code>
+      <code>$lazyServices['class_map']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1"/>
+    <MixedArrayAccess occurrences="2">
+      <code>$lazyServices['class_map']</code>
+      <code>$lazyServices['class_map']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="7">
+      <code>$callSequences[]</code>
+      <code>$factories['non-class-string']</code>
+      <code>$factories['non-class-string']</code>
+      <code>$invalidDelegators['invalid-classname']</code>
+      <code>$invalidDelegators['non-invokable-class']</code>
+      <code>$smTemplates[]</code>
+      <code>$tests[]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="1">
+      <code>$names[$name]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="68">
+      <code>$callSequence</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$first</code>
+      <code>$instance</code>
+      <code>$instance</code>
+      <code>$invalidDelegators</code>
+      <code>$lazyServices</code>
+      <code>$name</code>
+      <code>$names[$name]</code>
+      <code>$newServiceManager</code>
+      <code>$newServiceManager</code>
+      <code>$object1</code>
+      <code>$object1</code>
+      <code>$object1</code>
+      <code>$object1</code>
+      <code>$object1</code>
+      <code>$object2</code>
+      <code>$object2</code>
+      <code>$object2</code>
+      <code>$object2</code>
+      <code>$object2</code>
+      <code>$second</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$serviceManager</code>
+      <code>$shared</code>
+      <code>$shared</code>
+      <code>$sm</code>
+      <code>$sm</code>
+      <code>$sm</code>
+      <code>$smTemplate</code>
+      <code>$smTemplates[]</code>
+    </MixedAssignment>
+    <MixedClone occurrences="1">
+      <code>clone $smTemplate</code>
+    </MixedClone>
+    <MixedFunctionCall occurrences="2">
+      <code>$callback()</code>
+      <code>$callback()</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="82">
+      <code>$method</code>
+      <code>addAbstractFactory</code>
+      <code>addAbstractFactory</code>
+      <code>addAbstractFactory</code>
+      <code>addAbstractFactory</code>
+      <code>addDelegator</code>
+      <code>addInitializer</code>
+      <code>build</code>
+      <code>build</code>
+      <code>build</code>
+      <code>configure</code>
+      <code>configure</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getAllowOverride</code>
+      <code>getAllowOverride</code>
+      <code>getServiceLocator</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>mapLazyService</code>
+      <code>setAlias</code>
+      <code>setAlias</code>
+      <code>setAllowOverride</code>
+      <code>setAllowOverride</code>
+      <code>setFactory</code>
+      <code>setInvokableClass</code>
+      <code>setService</code>
+      <code>setShared</code>
+    </MixedMethodCall>
+    <MixedPropertyAssignment occurrences="2">
+      <code>$instance</code>
+      <code>$instance</code>
+    </MixedPropertyAssignment>
+    <PossiblyUndefinedVariable occurrences="4">
+      <code>$callSequences</code>
+      <code>$smTemplates</code>
+      <code>$tests</code>
+      <code>$tests</code>
+    </PossiblyUndefinedVariable>
+    <UndefinedDocblockClass occurrences="1">
+      <code>ContainerInterface</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="test/ConfigTest.php">
+    <MissingParamType occurrences="1">
+      <code>$dependencies</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>testMergeArrays</code>
+      <code>testPassesKnownServiceConfigKeysToServiceManagerWithConfigMethod</code>
+      <code>testToArrayReturnsConfiguration</code>
+    </MissingReturnType>
+    <MixedArrayAccess occurrences="2">
+      <code>$dependencies['array']</code>
+      <code>$dependencies['config']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$configInstance</code>
+      <code>$configuration</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>toArray</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/Exception/CyclicAliasExceptionTest.php">
+    <MissingReturnType occurrences="2">
+      <code>testFromAliasesMap</code>
+      <code>testFromCyclicAlias</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testFromCyclicAlias</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="test/Factory/InvokableFactoryTest.php">
+    <MissingReturnType occurrences="1">
+      <code>testCanCreateObject</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/LazyServiceIntegrationTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$autoload</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($autoload) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="3">
+      <code>$directory</code>
+      <code>$message</code>
+      <code>$message</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$proxyDir</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="9">
+      <code>assertProxyDirEmpty</code>
+      <code>assertProxyFileWritten</code>
+      <code>listProxyFiles</code>
+      <code>removeDir</code>
+      <code>testCanUseLazyServiceFactoryFactoryToCreateLazyServiceFactoryToActAsDelegatorToCreateLazyService</code>
+      <code>testMissingClassMapRaisesExceptionOnAttemptToRetrieveLazyService</code>
+      <code>testOnlyOneProxyAutoloaderItsRegisteredOnSubsequentCalls</code>
+      <code>testRaisesServiceNotFoundExceptionIfRequestedLazyServiceIsNotInClassMap</code>
+      <code>testWillNotGenerateProxyClassFilesByDefault</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="8">
+      <code>$directory</code>
+      <code>$directory</code>
+      <code>$message</code>
+      <code>$message</code>
+      <code>$this-&gt;listProxyFiles()</code>
+      <code>$this-&gt;listProxyFiles()</code>
+      <code>$this-&gt;proxyDir</code>
+      <code>$this-&gt;proxyDir</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$instance</code>
+      <code>$message</code>
+      <code>$message</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$directory</code>
+    </MixedOperand>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>AutoloaderInterface[]</code>
+      <code>array_filter(spl_autoload_functions(), $filter)</code>
+    </MixedReturnTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>assertIsArray</code>
+      <code>assertIsArray</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Proxy/LazyServiceFactoryTest.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>'stdClass'</code>
+      <code>'stdClass'</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="2">
+      <code>setMethods</code>
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <InvalidArgument occurrences="2">
+      <code>[$callback, 'callback']</code>
+      <code>[$callback, 'callback']</code>
+    </InvalidArgument>
+    <MissingClosureParamType occurrences="2">
+      <code>$className</code>
+      <code>$initializer</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="3">
+      <code>testCreates</code>
+      <code>testImplementsDelegatorFactoryInterface</code>
+      <code>testThrowExceptionWhenServiceNotExists</code>
+    </MissingReturnType>
+    <MixedFunctionCall occurrences="1"/>
+    <MixedMethodCall occurrences="3">
+      <code>method</code>
+      <code>method</code>
+      <code>willReturnCallback</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$container</code>
+      <code>$container</code>
+    </PossiblyInvalidArgument>
+    <UndefinedDocblockClass occurrences="5">
+      <code>$container</code>
+      <code>$this-&gt;proxyFactory</code>
+      <code>$this-&gt;proxyFactory</code>
+      <code>ContainerInterface|MockObject</code>
+      <code>LazyLoadingValueHolderFactory|MockObject</code>
+    </UndefinedDocblockClass>
+    <UndefinedMethod occurrences="2">
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/ServiceManagerTest.php">
+    <MissingClosureParamType occurrences="8">
+      <code>$callback</code>
+      <code>$container</code>
+      <code>$context</code>
+      <code>$context</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="3">
+      <code>function (</code>
+      <code>function ($container, $name, $callback) {</code>
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="4">
+      <code>$serviceDefined</code>
+      <code>$serviceShared</code>
+      <code>$sharedByDefault</code>
+      <code>$shouldBeSameInstance</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="19">
+      <code>createContainer</code>
+      <code>sampleFactory</code>
+      <code>shareProvider</code>
+      <code>testAbstractFactoryShouldBeCheckedForResolvedAliasesInsteadOfAliasName</code>
+      <code>testAliasToAnExplicitServiceShouldWork</code>
+      <code>testCanWrapCreationInDelegators</code>
+      <code>testConfigurationCanBeMerged</code>
+      <code>testConfigurationTakesPrecedenceWhenMerged</code>
+      <code>testConfiguringADelegatorMultipleTimesDoesNotLeadToDuplicateDelegatorCalls</code>
+      <code>testFactoryMayBeStaticMethodDescribedByCallableString</code>
+      <code>testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory</code>
+      <code>testMapsOneToOneInvokablesAsInvokableFactoriesInternally</code>
+      <code>testResolvedAliasFromAbstractFactory</code>
+      <code>testResolvedAliasNoMatchingAbstractFactoryReturnsFalse</code>
+      <code>testServiceManagerIsAPsr11Container</code>
+      <code>testSetAliasShouldWorkWithRecursiveAlias</code>
+      <code>testShareability</code>
+      <code>testSharedServicesReferencingAliasShouldBeHonored</code>
+      <code>testSharedServicesReferencingInvokableAliasShouldBeHonored</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$serviceManager-&gt;get(stdClass::class)</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="15">
+      <code>$a</code>
+      <code>$alias</code>
+      <code>$alias</code>
+      <code>$b</code>
+      <code>$headAlias</code>
+      <code>$inc</code>
+      <code>$inc</code>
+      <code>$instance</code>
+      <code>$instance</code>
+      <code>$instance1</code>
+      <code>$instance1</code>
+      <code>$instance2</code>
+      <code>$instance2</code>
+      <code>$service</code>
+      <code>$service</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$callback()</code>
+    </MixedFunctionCall>
+    <MixedOperand occurrences="1">
+      <code>$inc</code>
+    </MixedOperand>
+    <MixedPropertyAssignment occurrences="1">
+      <code>$instance</code>
+    </MixedPropertyAssignment>
+    <MixedPropertyFetch occurrences="2">
+      <code>$instance-&gt;foo</code>
+      <code>$instance-&gt;option</code>
+    </MixedPropertyFetch>
+  </file>
+  <file src="test/TestAsset/AbstractFactoryFoo.php">
+    <FalsableReturnStatement occurrences="1">
+      <code>false</code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType occurrences="1">
+      <code>__invoke</code>
+    </InvalidFalsableReturnType>
+  </file>
+  <file src="test/TestAsset/CallTimesAbstractFactory.php">
+    <InvalidReturnType occurrences="1">
+      <code>__invoke</code>
+    </InvalidReturnType>
+    <MissingPropertyType occurrences="1">
+      <code>$callTimes</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>setCallTimes</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="1">
+      <code>self::$callTimes</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>int</code>
+    </MixedInferredReturnType>
+    <MixedOperand occurrences="1">
+      <code>self::$callTimes</code>
+    </MixedOperand>
+    <MixedReturnStatement occurrences="1">
+      <code>self::$callTimes</code>
+    </MixedReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$name</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="test/TestAsset/FactoryObject.php">
+    <MissingParamType occurrences="1">
+      <code>$dependency</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$dependency</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/FailingAbstractFactory.php">
+    <InvalidReturnType occurrences="1">
+      <code>__invoke</code>
+    </InvalidReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$name</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="test/TestAsset/Foo.php">
+    <MissingParamType occurrences="1">
+      <code>$options</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$options</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/LenientPluginManager.php">
+    <MissingParamType occurrences="1">
+      <code>$instance</code>
+    </MissingParamType>
+  </file>
+  <file src="test/TestAsset/ObjectWithScalarDependency.php">
+    <MissingParamType occurrences="2">
+      <code>$aName</code>
+      <code>$aValue</code>
+    </MissingParamType>
+  </file>
+  <file src="test/TestAsset/PassthroughDelegatorFactory.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>__invoke</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$callback()</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="test/TestAsset/PreDelegator.php">
+    <MixedAssignment occurrences="4">
+      <code>$config</code>
+      <code>$instance</code>
+      <code>$key</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>__invoke</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$callback()</code>
+      <code>$instance</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="test/TestAsset/SimpleAbstractFactory.php">
+    <InvalidStringClass occurrences="2">
+      <code>new $className($options)</code>
+      <code>new $className()</code>
+    </InvalidStringClass>
+    <ParamNameMismatch occurrences="1">
+      <code>$name</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="test/TestAsset/V2ValidationPluginManager.php">
+    <MissingParamType occurrences="1">
+      <code>$plugin</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$assertion</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>validatePlugin</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/V2v3PluginManager.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="2">
+      <code>$plugin</code>
+      <code>$plugin</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$shareByDefault</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>validatePlugin</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$plugin</code>
+      <code>$this-&gt;instanceOf</code>
+    </MixedArgument>
+    <UndefinedClass occurrences="1">
+      <code>\ZendTest\ServiceManager\TestAsset\InvokableObject</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/TestAsset/factories/ComplexDependencyObject.php">
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get(\LaminasTest\ServiceManager\TestAsset\SecondComplexDependencyObject::class)</code>
+      <code>$container-&gt;get(\LaminasTest\ServiceManager\TestAsset\SimpleDependencyObject::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="test/TestAsset/factories/SimpleDependencyObject.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get(\LaminasTest\ServiceManager\TestAsset\InvokableObject::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="test/Tool/ConfigDumperCommandTest.php">
+    <MissingParamType occurrences="4">
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$message</code>
+      <code>$stream</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="14">
+      <code>assertErrorRaised</code>
+      <code>assertHelp</code>
+      <code>helpArguments</code>
+      <code>ignoreUnresolvedArguments</code>
+      <code>testEmitsConfigFileToStdoutWhenSuccessful</code>
+      <code>testEmitsErrorWhenClassDoesNotExist</code>
+      <code>testEmitsErrorWhenConfigurationFileDoesNotReturnArray</code>
+      <code>testEmitsErrorWhenTooFewArgumentsPresent</code>
+      <code>testEmitsErrorWhenUnableToCreateConfiguration</code>
+      <code>testEmitsHelpWhenHelpArgumentProvidedAsFirstArgument</code>
+      <code>testEmitsHelpWhenNoArgumentsProvided</code>
+      <code>testGeneratesConfigFileIgnoringUnresolved</code>
+      <code>testGeneratesConfigFileWhenProvidedConfigurationFileNotFound</code>
+      <code>testRaisesExceptionIfConfigFileNotFoundAndDirectoryNotWritable</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="13">
+      <code>$factoryConfig[ObjectWithObjectScalarDependency::class]</code>
+      <code>$factoryConfig[ObjectWithObjectScalarDependency::class]</code>
+      <code>$factoryConfig[SimpleDependencyObject::class]</code>
+      <code>$factoryConfig[SimpleDependencyObject::class]</code>
+      <code>$factoryConfig[SimpleDependencyObject::class]</code>
+      <code>$message</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="10">
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+      <code>$command</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="10">
+      <code>$command([$argument, $config, ObjectWithObjectScalarDependency::class])</code>
+      <code>$command([$argument])</code>
+      <code>$command([$config, 'Not\A\Real\Class'])</code>
+      <code>$command([$config, 'Not\A\Real\Class'])</code>
+      <code>$command([$config, 'Not\A\Real\Class'])</code>
+      <code>$command([$config, ObjectWithScalarDependency::class])</code>
+      <code>$command([$config, SimpleDependencyObject::class])</code>
+      <code>$command([$config, SimpleDependencyObject::class])</code>
+      <code>$command(['foo'])</code>
+      <code>$command([])</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="10">
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>writeErrorMessage</code>
+      <code>writeLine</code>
+      <code>writeLine</code>
+      <code>writeLine</code>
+      <code>writeLine</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="3">
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;helper</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="22">
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;command</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;configDir</code>
+      <code>$this-&gt;helper</code>
+      <code>$this-&gt;helper</code>
+      <code>$this-&gt;helper</code>
+      <code>$this-&gt;helper</code>
+      <code>$this-&gt;helper</code>
+    </UndefinedThisPropertyFetch>
+    <UnresolvableInclude occurrences="3">
+      <code>include $config</code>
+      <code>include $config</code>
+      <code>include $config</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/Tool/ConfigDumperTest.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>42</code>
+      <code>42</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="21">
+      <code>testCreateDependencyConfigClassWithoutConstructorHandlesAsInvokable</code>
+      <code>testCreateDependencyConfigExceptsIfClassDoesNotExist</code>
+      <code>testCreateDependencyConfigExceptsIfClassNameIsNotString</code>
+      <code>testCreateDependencyConfigInvokableObjectReturnsEmptyArray</code>
+      <code>testCreateDependencyConfigSimpleDependencyReturnsCorrectly</code>
+      <code>testCreateDependencyConfigWithContainerAndNoServiceWithoutTypeHintedParameterExcepts</code>
+      <code>testCreateDependencyConfigWithContainerWithoutTypeHintedParameter</code>
+      <code>testCreateDependencyConfigWithoutTypeHintedParameterExcepts</code>
+      <code>testCreateDependencyConfigWithoutTypeHintedParameterIgnoringUnresolved</code>
+      <code>testCreateDependencyConfigWorksWithExistingConfig</code>
+      <code>testCreateDependencyConfigWorksWithMultipleDependenciesOfSameType</code>
+      <code>testCreateFactoryMappingsAddsClassIfNotExists</code>
+      <code>testCreateFactoryMappingsExceptsIfClassDoesNotExist</code>
+      <code>testCreateFactoryMappingsExceptsIfClassNameIsNotString</code>
+      <code>testCreateFactoryMappingsFromConfigExceptsWhenConfigNotArray</code>
+      <code>testCreateFactoryMappingsFromConfigReturnsIfNoConfigKey</code>
+      <code>testCreateFactoryMappingsFromConfigWithWorkingConfig</code>
+      <code>testCreateFactoryMappingsIgnoresExistingsMappings</code>
+      <code>testCreateFactoryMappingsReturnsUnmodifiedArrayIfMappingExists</code>
+      <code>testDumpConfigFileReturnsContentsForConfigFileUsingUsingClassNotationAndShortArrays</code>
+      <code>testWillDumpConfigForClassDependingOnInterfaceButOmitInterfaceConfig</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="1">
+      <code>$test</code>
+    </MixedAssignment>
+    <UnresolvableInclude occurrences="1">
+      <code>include $file</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/Tool/FactoryCreatorCommandTest.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>Argument::containingString($message)</code>
+      <code>Argument::containingString('&lt;info&gt;Usage:&lt;/info&gt;')</code>
+    </ImplicitToStringCast>
+    <MissingParamType occurrences="4">
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$message</code>
+      <code>$stream</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="9">
+      <code>assertErrorRaised</code>
+      <code>assertHelp</code>
+      <code>helpArguments</code>
+      <code>invalidArguments</code>
+      <code>testEmitsErrorMessageIfArgumentIsNotAClass</code>
+      <code>testEmitsErrorWhenUnableToCreateFactory</code>
+      <code>testEmitsFactoryFileToStdoutWhenSuccessful</code>
+      <code>testEmitsHelpWhenHelpArgumentProvidedAsFirstArgument</code>
+      <code>testEmitsHelpWhenNoArgumentsProvided</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$argument</code>
+      <code>$message</code>
+      <code>$stream</code>
+      <code>ConfigDumperCommand::class</code>
+    </MixedArgument>
+    <PossiblyNullReference occurrences="3">
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+    </PossiblyNullReference>
+    <UndefinedClass occurrences="1">
+      <code>ConfigDumperCommand</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Tool/FactoryCreatorTest.php">
+    <MissingReturnType occurrences="3">
+      <code>testCreateFactoryCreatesForComplexDependencies</code>
+      <code>testCreateFactoryCreatesForInvokable</code>
+      <code>testCreateFactoryCreatesForSimpleDependencies</code>
+    </MissingReturnType>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
+<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
   <file src="src/AbstractFactory/ConfigAbstractFactory.php">
     <InvalidStringClass occurrences="1">
       <code>new $requestedName(...$arguments)</code>
@@ -17,15 +17,9 @@
     </MixedAssignment>
   </file>
   <file src="src/AbstractFactory/ReflectionBasedAbstractFactory.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$requestedName</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$requestedName</code>
     </ArgumentTypeCoercion>
-    <InvalidStringClass occurrences="3">
-      <code>new $requestedName()</code>
-      <code>new $requestedName()</code>
-      <code>new $requestedName(...$parameters)</code>
-    </InvalidStringClass>
     <LessSpecificReturnStatement occurrences="3">
       <code>new $requestedName()</code>
       <code>new $requestedName()</code>
@@ -35,6 +29,19 @@
       <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
       <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
     </MissingClosureReturnType>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MixedArgument occurrences="3">
+      <code>$requestedName</code>
+      <code>$requestedName</code>
+      <code>$requestedName</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="3">
+      <code>new $requestedName()</code>
+      <code>new $requestedName()</code>
+      <code>new $requestedName(...$parameters)</code>
+    </MixedMethodCall>
     <MoreSpecificReturnType occurrences="1">
       <code>DispatchableInterface</code>
     </MoreSpecificReturnType>
@@ -55,18 +62,15 @@
   </file>
   <file src="src/AbstractPluginManager.php">
     <DocblockTypeContradiction occurrences="2">
+      <code>gettype($configInstanceOrParentLocator)</code>
       <code>gettype($instance)</code>
     </DocblockTypeContradiction>
-    <MissingParamType occurrences="1">
-      <code>$instance</code>
-    </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>setService</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$instance</code>
       <code>$service</code>
-      <code>$this-&gt;instanceOf</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$instance</code>
@@ -78,7 +82,8 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$service</code>
     </PossiblyInvalidArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>is_object($configInstanceOrParentLocator)</code>
       <code>is_object($instance)</code>
     </RedundantConditionGivenDocblockType>
   </file>
@@ -109,14 +114,14 @@
     </PossiblyFalseOperand>
   </file>
   <file src="src/Factory/DelegatorFactoryInterface.php">
-    <UndefinedDocblockClass occurrences="1">
+    <InvalidThrow occurrences="1">
       <code>ContainerException</code>
-    </UndefinedDocblockClass>
+    </InvalidThrow>
   </file>
   <file src="src/Factory/FactoryInterface.php">
-    <UndefinedDocblockClass occurrences="1">
+    <InvalidThrow occurrences="1">
       <code>ContainerException</code>
-    </UndefinedDocblockClass>
+    </InvalidThrow>
   </file>
   <file src="src/Factory/InvokableFactory.php">
     <InvalidStringClass occurrences="2">
@@ -130,20 +135,26 @@
     </MissingParamType>
   </file>
   <file src="src/PluginManagerInterface.php">
-    <UndefinedDocblockClass occurrences="1">
+    <InvalidThrow occurrences="1">
       <code>ContainerException</code>
-    </UndefinedDocblockClass>
+    </InvalidThrow>
   </file>
   <file src="src/Proxy/LazyServiceFactory.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;servicesMap[$name]</code>
-    </ArgumentTypeCoercion>
     <MissingClosureParamType occurrences="1">
       <code>$wrappedInstance</code>
     </MissingClosureParamType>
     <MissingClosureReturnType occurrences="1">
       <code>function (&amp;$wrappedInstance, LazyLoadingInterface $proxy) use ($callback) {</code>
     </MissingClosureReturnType>
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MixedArgument occurrences="1">
+      <code>$name</code>
+    </MixedArgument>
+    <MixedArrayOffset occurrences="1">
+      <code>$this-&gt;servicesMap[$name]</code>
+    </MixedArrayOffset>
     <MixedAssignment occurrences="1">
       <code>$wrappedInstance</code>
     </MixedAssignment>
@@ -162,7 +173,7 @@
       <code>$abstractFactories</code>
     </InvalidDocblockParamName>
     <InvalidThrow occurrences="1">
-      <code>ExceptionInterface</code>
+      <code>ContainerException</code>
     </InvalidThrow>
     <MissingClosureReturnType occurrences="2">
       <code>function () use ($delegatorFactory, $name, $creationCallback, $options) {</code>
@@ -175,13 +186,10 @@
       <code>$allowOverride</code>
       <code>$this-&gt;allowOverride</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="15">
+    <MissingReturnType occurrences="11">
       <code>addAbstractFactory</code>
       <code>addDelegator</code>
       <code>addInitializer</code>
-      <code>createAliasesAndFactoriesForInvokables</code>
-      <code>mapAliasToTarget</code>
-      <code>mapAliasesToTargets</code>
       <code>mapLazyService</code>
       <code>resolveInitializers</code>
       <code>setAlias</code>
@@ -190,16 +198,13 @@
       <code>setInvokableClass</code>
       <code>setService</code>
       <code>setShared</code>
-      <code>validateServiceNames</code>
     </MissingReturnType>
-    <MixedArgument occurrences="20">
-      <code>$alias</code>
-      <code>$alias</code>
-      <code>$alias</code>
+    <MixedArgument occurrences="15">
       <code>$config['delegators']</code>
       <code>$config['initializers']</code>
       <code>$config['invokables']</code>
       <code>$config['lazy_services']</code>
+      <code>$object</code>
       <code>$service</code>
       <code>$service</code>
       <code>$service</code>
@@ -207,36 +212,15 @@
       <code>$service</code>
       <code>$service</code>
       <code>$service</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
       <code>$this-&gt;lazyServices['class_map']</code>
       <code>$this-&gt;lazyServices['proxies_namespace']</code>
       <code>$this-&gt;lazyServices['proxies_target_dir']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="5">
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>$alias</code>
       <code>$alias</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;aliases[$alias]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="3">
-      <code>$this-&gt;aliases[$alias]</code>
-      <code>$this-&gt;aliases[$name]</code>
-      <code>$this-&gt;factories[$class]</code>
-    </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="15">
-      <code>$tagged[$aCursor]</code>
-      <code>$tagged[$alias]</code>
-      <code>$tagged[$alias]</code>
-      <code>$this-&gt;aliases[$alias]</code>
-      <code>$this-&gt;aliases[$alias]</code>
-      <code>$this-&gt;aliases[$tCursor]</code>
-      <code>$this-&gt;aliases[$tCursor]</code>
+    <MixedArrayOffset occurrences="8">
       <code>$this-&gt;factories[$class]</code>
       <code>$this-&gt;services[$service]</code>
       <code>$this-&gt;services[$service]</code>
@@ -246,20 +230,14 @@
       <code>$this-&gt;services[$service]</code>
       <code>$this-&gt;services[$service]</code>
     </MixedArrayOffset>
-    <MixedArrayTypeCoercion occurrences="2">
-      <code>$this-&gt;aliases[$tCursor]</code>
-      <code>$this-&gt;aliases[$tCursor]</code>
-    </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="31">
-      <code>$aCursor</code>
-      <code>$aCursor</code>
+    <MixedAssignment occurrences="22">
       <code>$abstractFactories</code>
       <code>$abstractFactory</code>
       <code>$abstractFactory</code>
-      <code>$alias</code>
-      <code>$alias</code>
       <code>$class</code>
+      <code>$config['aliases']</code>
       <code>$key</code>
+      <code>$newAliases[$name]</code>
       <code>$object</code>
       <code>$object</code>
       <code>$object</code>
@@ -270,14 +248,7 @@
       <code>$service</code>
       <code>$service</code>
       <code>$service</code>
-      <code>$stack[]</code>
-      <code>$tCursor</code>
-      <code>$tCursor</code>
-      <code>$target</code>
       <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;factories</code>
       <code>$this-&gt;factories</code>
       <code>$this-&gt;services</code>
       <code>$this-&gt;shared</code>
@@ -293,20 +264,28 @@
       <code>new $factory()</code>
       <code>new $initializer()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="4">
+    <MixedOperand occurrences="5">
       <code>$config['aliases']</code>
+      <code>$config['aliases'] ?? []</code>
       <code>$config['factories']</code>
       <code>$config['services']</code>
       <code>$config['shared']</code>
     </MixedOperand>
-    <MixedPropertyTypeCoercion occurrences="2">
-      <code>$this-&gt;aliases</code>
+    <MixedPropertyTypeCoercion occurrences="1">
       <code>$this-&gt;aliases</code>
     </MixedPropertyTypeCoercion>
     <MixedReturnStatement occurrences="2">
       <code>$creationCallback($this-&gt;creationContext, $name, $creationCallback, $options)</code>
       <code>$this-&gt;allowOverride</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$factory</code>
+      <code>callable</code>
+    </MixedReturnTypeCoercion>
+    <ParamNameMismatch occurrences="2">
+      <code>$name</code>
+      <code>$name</code>
+    </ParamNameMismatch>
     <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;delegators</code>
     </PropertyTypeCoercion>
@@ -332,6 +311,14 @@
     <TypeDoesNotContainType occurrences="1">
       <code>$sharedAlias</code>
     </TypeDoesNotContainType>
+    <UnusedForeachValue occurrences="3">
+      <code>$delegatorFactory</code>
+      <code>$service</code>
+      <code>$target</code>
+    </UnusedForeachValue>
+    <UnusedVariable occurrences="1">
+      <code>$key</code>
+    </UnusedVariable>
   </file>
   <file src="src/Test/CommonPluginManagerTrait.php">
     <MissingParamType occurrences="2">
@@ -373,7 +360,8 @@
     <MissingReturnType occurrences="1">
       <code>validateClassName</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
+      <code>$argumentType</code>
       <code>$config['service_manager']</code>
       <code>$config['service_manager']['factories']</code>
     </MixedArgument>
@@ -385,7 +373,9 @@
       <code>$config[ConfigAbstractFactory::class][$className]</code>
       <code>$config[ConfigAbstractFactory::class][$className]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="4">
+      <code>$argumentType</code>
+      <code>$classConfig[]</code>
       <code>$dependency</code>
       <code>$value</code>
     </MixedAssignment>
@@ -401,6 +391,12 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;container</code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedMethod occurrences="1">
+      <code>getName</code>
+    </UndefinedMethod>
+    <UnusedForeachValue occurrences="1">
+      <code>$dependency</code>
+    </UnusedForeachValue>
   </file>
   <file src="src/Tool/ConfigDumperCommand.php">
     <MixedArgument occurrences="14">
@@ -435,11 +431,19 @@
     <MissingParamType occurrences="1">
       <code>$className</code>
     </MissingParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$className</code>
       <code>$className</code>
-      <code>$dependency</code>
     </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$class</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>?string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>null !== $type &amp;&amp; ! $type-&gt;isBuiltin() ? $type-&gt;getName() : null</code>
+    </MixedReturnStatement>
     <PossiblyFalseOperand occurrences="1">
       <code>strrpos($className, '\\')</code>
     </PossiblyFalseOperand>
@@ -449,6 +453,10 @@
     <TypeDoesNotContainType occurrences="1">
       <code>! $reflectionClass</code>
     </TypeDoesNotContainType>
+    <UndefinedMethod occurrences="2">
+      <code>getName</code>
+      <code>getName</code>
+    </UndefinedMethod>
   </file>
   <file src="src/Tool/FactoryCreatorCommand.php">
     <MixedArgument occurrences="5">
@@ -515,7 +523,7 @@
       <code>testFactoryWillUseDefaultValueForTypeHintedArgument</code>
       <code>testFactoryWillUseDefaultValueWhenPresentForScalarArgument</code>
     </MissingReturnType>
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="14">
       <code>$requestedName</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
@@ -530,8 +538,6 @@
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
-      <code>SampleInterface::class</code>
-      <code>\LaminasTest\ServiceManager\AbstractFactory\ArrayAccess::class</code>
     </MixedArgument>
     <MixedMethodCall occurrences="6">
       <code>willReturn</code>
@@ -541,9 +547,7 @@
       <code>willReturn</code>
       <code>willReturn</code>
     </MixedMethodCall>
-    <PossiblyInvalidMethodCall occurrences="15">
-      <code>willReturn</code>
-      <code>willReturn</code>
+    <PossiblyInvalidMethodCall occurrences="13">
       <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
@@ -573,10 +577,6 @@
       <code>reveal</code>
       <code>reveal</code>
     </PossiblyUndefinedMethod>
-    <UndefinedClass occurrences="2">
-      <code>SampleInterface</code>
-      <code>\LaminasTest\ServiceManager\AbstractFactory\ArrayAccess</code>
-    </UndefinedClass>
   </file>
   <file src="test/AbstractFactory/TestAsset/ClassWithScalarDependencyDefiningDefaultValue.php">
     <MissingPropertyType occurrences="1">
@@ -602,6 +602,10 @@
     <DeprecatedMethod occurrences="1">
       <code>setServiceLocator</code>
     </DeprecatedMethod>
+    <InternalMethod occurrences="1">
+      <code>getContainer</code>
+    </InternalMethod>
+    <InvalidArgument occurrences="6"/>
     <MissingClosureParamType occurrences="16">
       <code>$callback</code>
       <code>$container</code>
@@ -628,7 +632,7 @@
       <code>$arg</code>
       <code>$shareByDefault</code>
     </MissingParamType>
-    <MissingReturnType occurrences="22">
+    <MissingReturnType occurrences="23">
       <code>createContainer</code>
       <code>invalidConstructorArguments</code>
       <code>shareByDefaultSettings</code>
@@ -649,6 +653,7 @@
       <code>testReturnsDiscreteInstancesIfOptionsAreProvidedRegardlessOfShareByDefaultSetting</code>
       <code>testSetServiceShouldRaiseExceptionForInvalidPlugin</code>
       <code>testSupportsRetrievingAutoInvokableServicesByDefault</code>
+      <code>testTransparentlyDecoratesNonInteropPsrContainerAsInteropContainer</code>
       <code>testValidateInstance</code>
       <code>testValidateWillFallBackToValidatePluginWhenDefinedAndEmitDeprecationNotice</code>
     </MissingReturnType>
@@ -657,7 +662,6 @@
       <code>$errmsg</code>
       <code>$pluginManager</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="6"/>
     <MixedAssignment occurrences="3">
       <code>$instance</code>
       <code>$instance</code>
@@ -676,10 +680,22 @@
       <code>$instance-&gt;foo</code>
       <code>$instance-&gt;option</code>
     </MixedPropertyFetch>
+    <UnusedClosureParam occurrences="7">
+      <code>$container</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$errstr</code>
+      <code>$name</code>
+    </UnusedClosureParam>
   </file>
   <file src="test/CommonServiceLocatorBehaviorsTrait.php">
-    <InvalidArgument occurrences="1">
-      <code>ContainerExceptionInterface::class</code>
+    <EmptyArrayAccess occurrences="1">
+      <code>$object['get'][0]</code>
+    </EmptyArrayAccess>
+    <InvalidArgument occurrences="2">
+      <code>ContainerException::class</code>
     </InvalidArgument>
     <InvalidArrayOffset occurrences="1">
       <code>$config['shared']</code>
@@ -706,7 +722,7 @@
       <code>function ($container, $name, $callback) {</code>
       <code>function ($container, $requestedName, array $options = null) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="11">
+    <MissingParamType occurrences="13">
       <code>$abstractFactory</code>
       <code>$args</code>
       <code>$container</code>
@@ -718,13 +734,13 @@
       <code>$factory</code>
       <code>$initializer</code>
       <code>$method</code>
+      <code>$shared</code>
+      <code>$test</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="1">
       <code>$creationContext</code>
-      <code>$this-&gt;creationContext</code>
-      <code>$this-&gt;creationContext</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="52">
+    <MissingReturnType occurrences="53">
       <code>abstractFactories</code>
       <code>invalidAbstractFactories</code>
       <code>invalidDelegators</code>
@@ -759,6 +775,7 @@
       <code>testCheckingServiceExistenceWithChecksAgainstAbstractFactories</code>
       <code>testConfigureCanAddNewServices</code>
       <code>testConfigureCanOverridePreviousSettings</code>
+      <code>testConfigureInvokablesTakePrecedenceOverFactories</code>
       <code>testConfiguringInstanceRaisesExceptionIfAllowOverrideIsFalse</code>
       <code>testConsistencyOverInternalStates</code>
       <code>testCoverageDepthFirstTaggingOnRecursiveAliasDefinitions</code>
@@ -786,24 +803,25 @@
       <code>$lazyServices</code>
       <code>$lazyServices['class_map']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1"/>
     <MixedArrayAccess occurrences="2">
       <code>$lazyServices['class_map']</code>
       <code>$lazyServices['class_map']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="7">
+    <MixedArrayAssignment occurrences="8">
       <code>$callSequences[]</code>
       <code>$factories['non-class-string']</code>
       <code>$factories['non-class-string']</code>
       <code>$invalidDelegators['invalid-classname']</code>
       <code>$invalidDelegators['non-invokable-class']</code>
+      <code>$object[$shared ? $method : 'build'][]</code>
       <code>$smTemplates[]</code>
       <code>$tests[]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset occurrences="2">
       <code>$names[$name]</code>
+      <code>$object[$shared ? $method : 'build']</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="68">
+    <MixedAssignment occurrences="76">
       <code>$callSequence</code>
       <code>$container</code>
       <code>$container</code>
@@ -820,14 +838,20 @@
       <code>$factories</code>
       <code>$factories</code>
       <code>$first</code>
+      <code>$idx1</code>
+      <code>$idx2</code>
       <code>$instance</code>
       <code>$instance</code>
       <code>$invalidDelegators</code>
       <code>$lazyServices</code>
+      <code>$method</code>
       <code>$name</code>
       <code>$names[$name]</code>
       <code>$newServiceManager</code>
       <code>$newServiceManager</code>
+      <code>$nonSharedObj1</code>
+      <code>$nonSharedObj2</code>
+      <code>$obj</code>
       <code>$object1</code>
       <code>$object1</code>
       <code>$object1</code>
@@ -838,7 +862,9 @@
       <code>$object2</code>
       <code>$object2</code>
       <code>$object2</code>
+      <code>$object[$shared ? $method : 'build'][]</code>
       <code>$second</code>
+      <code>$serviceManager</code>
       <code>$serviceManager</code>
       <code>$serviceManager</code>
       <code>$serviceManager</code>
@@ -880,7 +906,7 @@
       <code>$callback()</code>
       <code>$callback()</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="82">
+    <MixedMethodCall occurrences="83">
       <code>$method</code>
       <code>addAbstractFactory</code>
       <code>addAbstractFactory</code>
@@ -893,6 +919,7 @@
       <code>build</code>
       <code>configure</code>
       <code>configure</code>
+      <code>get</code>
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -968,15 +995,28 @@
       <code>$instance</code>
       <code>$instance</code>
     </MixedPropertyAssignment>
-    <PossiblyUndefinedVariable occurrences="4">
+    <PossiblyUndefinedVariable occurrences="5">
       <code>$callSequences</code>
+      <code>$object</code>
       <code>$smTemplates</code>
       <code>$tests</code>
       <code>$tests</code>
     </PossiblyUndefinedVariable>
-    <UndefinedDocblockClass occurrences="1">
-      <code>ContainerInterface</code>
-    </UndefinedDocblockClass>
+    <UnusedClosureParam occurrences="10">
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$errstr</code>
+      <code>$name</code>
+      <code>$options</code>
+      <code>$requestedName</code>
+      <code>$serviceLocator</code>
+    </UnusedClosureParam>
+    <UnusedVariable occurrences="1">
+      <code>$sm</code>
+    </UnusedVariable>
   </file>
   <file src="test/ConfigTest.php">
     <MissingParamType occurrences="1">
@@ -1000,12 +1040,11 @@
     </MixedMethodCall>
   </file>
   <file src="test/Exception/CyclicAliasExceptionTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType occurrences="1">
       <code>testFromAliasesMap</code>
-      <code>testFromCyclicAlias</code>
     </MissingReturnType>
     <PossiblyInvalidArgument occurrences="1">
-      <code>testFromCyclicAlias</code>
+      <code>testFromAliasesMap</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/Factory/InvokableFactoryTest.php">
@@ -1014,6 +1053,12 @@
     </MissingReturnType>
   </file>
   <file src="test/LazyServiceIntegrationTest.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>array_filter(spl_autoload_functions(), $filter)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>AutoloaderInterface[]</code>
+    </InvalidReturnType>
     <MissingClosureParamType occurrences="1">
       <code>$autoload</code>
     </MissingClosureParamType>
@@ -1057,10 +1102,6 @@
     <MixedOperand occurrences="1">
       <code>$directory</code>
     </MixedOperand>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>AutoloaderInterface[]</code>
-      <code>array_filter(spl_autoload_functions(), $filter)</code>
-    </MixedReturnTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>assertIsArray</code>
       <code>assertIsArray</code>
@@ -1109,6 +1150,30 @@
       <code>expects</code>
       <code>expects</code>
     </UndefinedMethod>
+    <UnusedVariable occurrences="1">
+      <code>$wrappedInstance</code>
+    </UnusedVariable>
+  </file>
+  <file src="test/PsrContainerDecoratorTest.php">
+    <InternalClass occurrences="3">
+      <code>new PsrContainerDecorator($psrContainer)</code>
+      <code>new PsrContainerDecorator($psrContainer)</code>
+      <code>new PsrContainerDecorator($psrContainer)</code>
+    </InternalClass>
+    <InternalMethod occurrences="7">
+      <code>get</code>
+      <code>getContainer</code>
+      <code>has</code>
+      <code>has</code>
+      <code>new PsrContainerDecorator($psrContainer)</code>
+      <code>new PsrContainerDecorator($psrContainer)</code>
+      <code>new PsrContainerDecorator($psrContainer)</code>
+    </InternalMethod>
+    <MissingReturnType occurrences="3">
+      <code>testGetterReturnsDecoratedContainer</code>
+      <code>testProxiesGetToDecoratedContainer</code>
+      <code>testProxiesHasToDecoratedContainer</code>
+    </MissingReturnType>
   </file>
   <file src="test/ServiceManagerTest.php">
     <MissingClosureParamType occurrences="8">
@@ -1141,7 +1206,7 @@
       <code>testCanWrapCreationInDelegators</code>
       <code>testConfigurationCanBeMerged</code>
       <code>testConfigurationTakesPrecedenceWhenMerged</code>
-      <code>testConfiguringADelegatorMultipleTimesDoesNotLeadToDuplicateDelegatorCalls</code>
+      <code>testConfigureMultipleTimesAvoidsDuplicates</code>
       <code>testFactoryMayBeStaticMethodDescribedByCallableString</code>
       <code>testMapsNonSymmetricInvokablesAsAliasPlusInvokableFactory</code>
       <code>testMapsOneToOneInvokablesAsInvokableFactoriesInternally</code>
@@ -1156,7 +1221,7 @@
     <MixedArgument occurrences="1">
       <code>$serviceManager-&gt;get(stdClass::class)</code>
     </MixedArgument>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="18">
       <code>$a</code>
       <code>$alias</code>
       <code>$alias</code>
@@ -1172,6 +1237,9 @@
       <code>$instance2</code>
       <code>$service</code>
       <code>$service</code>
+      <code>$service</code>
+      <code>$serviceFromAlias</code>
+      <code>$serviceFromServiceNameAfterUsingAlias</code>
     </MixedAssignment>
     <MixedFunctionCall occurrences="1">
       <code>$callback()</code>
@@ -1186,6 +1254,17 @@
       <code>$instance-&gt;foo</code>
       <code>$instance-&gt;option</code>
     </MixedPropertyFetch>
+    <UnusedClosureParam occurrences="6">
+      <code>$container</code>
+      <code>$container</code>
+      <code>$context</code>
+      <code>$context</code>
+      <code>$name</code>
+      <code>$name</code>
+    </UnusedClosureParam>
+    <UnusedVariable occurrences="1">
+      <code>$inc</code>
+    </UnusedVariable>
   </file>
   <file src="test/TestAsset/AbstractFactoryFoo.php">
     <FalsableReturnStatement occurrences="1">
@@ -1245,11 +1324,6 @@
       <code>$options</code>
     </MissingPropertyType>
   </file>
-  <file src="test/TestAsset/LenientPluginManager.php">
-    <MissingParamType occurrences="1">
-      <code>$instance</code>
-    </MissingParamType>
-  </file>
   <file src="test/TestAsset/ObjectWithScalarDependency.php">
     <MissingParamType occurrences="2">
       <code>$aName</code>
@@ -1303,8 +1377,7 @@
     <InvalidScalarArgument occurrences="1">
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="2">
-      <code>$plugin</code>
+    <MissingParamType occurrences="1">
       <code>$plugin</code>
     </MissingParamType>
     <MissingPropertyType occurrences="1">
@@ -1317,6 +1390,9 @@
       <code>$plugin</code>
       <code>$this-&gt;instanceOf</code>
     </MixedArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$plugin</code>
+    </ParamNameMismatch>
     <UndefinedClass occurrences="1">
       <code>\ZendTest\ServiceManager\TestAsset\InvokableObject</code>
     </UndefinedClass>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="bin"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,19 +15,6 @@
         </ignoreFiles>
     </projectFiles>
 
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
-            </errorLevel>
-        </InternalMethod>
-    </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>


### PR DESCRIPTION
fix #54 

* [x]  Create a `.psalm.xml.dist` in the project root
* [x] Copy and paste the contents from this [psalm.xml.dist](https://github.com/mezzio/repo-template/blob/6124090610ef1c6d6b0c80a063cafacc3ec68f38/psalm.xml.dist)
* [x] Run `$ composer require vimeo/psalm`
* [x] Run `$ vendor/bin/psalm --set-baseline=psalm-baseline.xml`
* [x] Add a composer script `static-analysis` with the command `psalm --shepherd --stats`
* [x] Add a new line to `script:` in `.travis.yml`: `- if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi`
* [x] Remove phpstan from the project (`phpstan.neon.dist`, `.travis.yml` entry, `composer.json` `require-dev` and `scripts`)

composer ^2.0 is now required in dev environnement
