### PR TITLE
Fix invokables merging precedence in `3.6.x`

### DIFF
--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -339,6 +339,29 @@ trait CommonServiceLocatorBehaviorsTrait
         $newServiceManager->get(DateTime::class);
     }
 
+    public function testConfigureInvokablesTakePrecedenceOverFactories()
+    {
+        $firstFactory  = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
+
+        $serviceManager = $this->createContainer([
+            'aliases' => [
+                'custom_alias' => DateTime::class,
+            ],
+            'factories' => [
+                DateTime::class => $firstFactory,
+            ],
+            'invokables' => [
+                'custom_alias' => stdClass::class,
+            ],
+        ]);
+
+        $firstFactory->expects($this->never())->method('__invoke');
+
+        $object = $serviceManager->get('custom_alias');
+        $this->assertInstanceOf(stdClass::class, $object);
+    }
+
     /**
      * @group has
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| New Feature   | no

### Description

This PR fixes a BC break introduced in Laminas service manager 3.6.x. When invokables are defined with an alias, that alias used to override other aliases in 3.5.x series, which does not happen anymore in 3.6.x.  See PR #75, where I have backported the same test case to the 3.5.x branch.

See ticket #68 for a discussion on the bug. Affected projects are, for instance, neilime/twbs-helper-module#128 and LM-Commons/LmcUser#13.
