### PR TITLE
backported testConfigureInvokablesTakePrecedenceOverFactories to 3.5.x

### DIFF
--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -327,6 +327,29 @@ trait CommonServiceLocatorBehaviorsTrait
         $newServiceManager->get(DateTime::class);
     }
 
+    public function testConfigureInvokablesTakePrecedenceOverFactories()
+    {
+        $firstFactory  = $this->getMockBuilder(FactoryInterface::class)
+            ->getMock();
+
+        $serviceManager = $this->createContainer([
+            'aliases' => [
+                'custom_alias' => DateTime::class,
+            ],
+            'factories' => [
+                DateTime::class => $firstFactory,
+            ],
+            'invokables' => [
+                'custom_alias' => stdClass::class,
+            ],
+        ]);
+
+        $firstFactory->expects($this->never())->method('__invoke');
+
+        $object = $serviceManager->get('custom_alias');
+        $this->assertInstanceOf(stdClass::class, $object);
+    }
+
     /**
      * @group has
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | no
| BC Break      | no
| New Feature   | no

### Description

This PR backports the new test case introduced in PR #74 to the 3.5.x branch.