### PR TITLE
Improve `ServiceManager#has()` performance

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -247,10 +247,7 @@ class ServiceManager implements ServiceLocatorInterface
     public function has($name)
     {
         // Check static services and factories first to speedup the most common requests.
-        return (
-            $this->staticServiceOrFactoryCanCreate($name) ||
-            $this->abstractFactoryCanCreate($name)
-        );
+        return $this->staticServiceOrFactoryCanCreate($name) || $this->abstractFactoryCanCreate($name);
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

We noticed that `ServiceManager::has()` was a pretty big bottleneck on a page using a very large amount of view helpers to render a large amount of data:

![image](https://user-images.githubusercontent.com/1873829/126794579-cdf965a8-0ce7-40a2-b08a-04d51514a744.png)

This was on a total duration of 5.61 seconds, which means it spent 87.5% of the time checking if services exist.

The problem seemed to be caused by [the way `has()` uses dynamically created closures](https://github.com/laminas/laminas-servicemanager/blob/e76870240e368edf699c50d4bbf32607ac94145c/src/ServiceManager.php#L967-L1011). This PR refactors that code to implement the same behavior using 2 private methods, avoiding the overhead that comes with it.

We're using this patch in production now and for this specific example the performance has improved drastically:

![image](https://user-images.githubusercontent.com/1873829/126795870-e3865940-12a7-417a-b3f3-10075ce09ece.png)

The logic itself remained exactly the same, I only changed the way it was written. I hope it helps, please let me know if I need to fix or clarify anything! :)