### PR TITLE
Explicitly declare that factories support `array<mixed>` for construct-time options, instead of just declaring `array`

### DIFF
--- a/src/Factory/FactoryInterface.php
+++ b/src/Factory/FactoryInterface.php
@@ -23,7 +23,7 @@ interface FactoryInterface
      * Create an object
      *
      * @param  string             $requestedName
-     * @param  null|array         $options
+     * @param  null|array<mixed>  $options
      * @return object
      * @throws ServiceNotFoundException If unable to resolve the service.
      * @throws ServiceNotCreatedException If an exception is raised when creating a service.


### PR DESCRIPTION
see https://github.com/Slamdunk/phpstan-laminas-framework/issues/26