### PR TITLE
[Php 7.4] Apply Php 7.4 Syntax

### DIFF
--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -162,6 +162,7 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
          * @return mixed
          * @throws ServiceNotFoundException If type-hinted parameter cannot be
          *   resolved to a service in the container.
+         * @psalm-suppress MissingClosureReturnType
          */
         return fn(ReflectionParameter $parameter) => $this->resolveParameter($parameter, $container, $requestedName);
     }

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -163,9 +163,7 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
          * @throws ServiceNotFoundException If type-hinted parameter cannot be
          *   resolved to a service in the container.
          */
-        return function (ReflectionParameter $parameter) use ($container, $requestedName) {
-            return $this->resolveParameter($parameter, $container, $requestedName);
-        };
+        return fn(ReflectionParameter $parameter) => $this->resolveParameter($parameter, $container, $requestedName);
     }
 
     /**

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -123,7 +123,7 @@ class CyclicAliasException extends InvalidArgumentException
         return implode(
             ' => ',
             array_map(
-                fn($cycle) => '"' . $cycle . '"',
+                fn($cycle): string => '"' . $cycle . '"',
                 $fullCycle
             )
         );

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -43,9 +43,7 @@ class CyclicAliasException extends InvalidArgumentException
     public static function fromAliasesMap(array $aliases)
     {
         $detectedCycles = array_filter(array_map(
-            function ($alias) use ($aliases) {
-                return self::getCycleFor($aliases, $alias);
-            },
+            fn($alias) => self::getCycleFor($aliases, $alias),
             array_keys($aliases)
         ));
 
@@ -125,9 +123,7 @@ class CyclicAliasException extends InvalidArgumentException
         return implode(
             ' => ',
             array_map(
-                function ($cycle) {
-                    return '"' . $cycle . '"';
-                },
+                fn($cycle) => '"' . $cycle . '"',
                 $fullCycle
             )
         );
@@ -148,7 +144,7 @@ class CyclicAliasException extends InvalidArgumentException
 
             $hash = serialize(array_values($cycleAliases));
 
-            $detectedCyclesByHash[$hash] = $detectedCyclesByHash[$hash] ?? $detectedCycle;
+            $detectedCyclesByHash[$hash] ??= $detectedCycle;
         }
 
         return array_values($detectedCyclesByHash);

--- a/src/Exception/CyclicAliasException.php
+++ b/src/Exception/CyclicAliasException.php
@@ -43,7 +43,7 @@ class CyclicAliasException extends InvalidArgumentException
     public static function fromAliasesMap(array $aliases)
     {
         $detectedCycles = array_filter(array_map(
-            fn($alias) => self::getCycleFor($aliases, $alias),
+            static fn($alias) => self::getCycleFor($aliases, $alias),
             array_keys($aliases)
         ));
 
@@ -123,7 +123,7 @@ class CyclicAliasException extends InvalidArgumentException
         return implode(
             ' => ',
             array_map(
-                fn($cycle): string => '"' . $cycle . '"',
+                static fn($cycle): string => '"' . $cycle . '"',
                 $fullCycle
             )
         );

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -591,15 +591,7 @@ class ServiceManager implements ServiceLocatorInterface
 
             $creationCallback =
                 /** @return object */
-                static function () use (
-                    $initialCreationContext,
-                    $delegatorFactory,
-                    $name,
-                    $creationCallback,
-                    $options
-                ) {
-                    return $delegatorFactory($initialCreationContext, $name, $creationCallback, $options);
-                };
+                static fn() => $delegatorFactory($initialCreationContext, $name, $creationCallback, $options);
         }
 
         return $creationCallback();

--- a/src/Tool/ConfigDumper.php
+++ b/src/Tool/ConfigDumper.php
@@ -72,7 +72,7 @@ EOC;
         $constructorArguments = $reflectionClass->getConstructor()->getParameters();
         $constructorArguments = array_filter(
             $constructorArguments,
-            fn(ReflectionParameter $argument) => ! $argument->isOptional()
+            fn(ReflectionParameter $argument): bool => ! $argument->isOptional()
         );
 
         // has no required parameters, treat it as an invokable

--- a/src/Tool/ConfigDumper.php
+++ b/src/Tool/ConfigDumper.php
@@ -72,7 +72,7 @@ EOC;
         $constructorArguments = $reflectionClass->getConstructor()->getParameters();
         $constructorArguments = array_filter(
             $constructorArguments,
-            fn(ReflectionParameter $argument): bool => ! $argument->isOptional()
+            static fn(ReflectionParameter $argument): bool => ! $argument->isOptional()
         );
 
         // has no required parameters, treat it as an invokable

--- a/src/Tool/ConfigDumper.php
+++ b/src/Tool/ConfigDumper.php
@@ -72,9 +72,7 @@ EOC;
         $constructorArguments = $reflectionClass->getConstructor()->getParameters();
         $constructorArguments = array_filter(
             $constructorArguments,
-            function (ReflectionParameter $argument) {
-                return ! $argument->isOptional();
-            }
+            fn(ReflectionParameter $argument) => ! $argument->isOptional()
         );
 
         // has no required parameters, treat it as an invokable

--- a/src/Tool/FactoryCreator.php
+++ b/src/Tool/FactoryCreator.php
@@ -27,13 +27,13 @@ class FactoryCreator
 {
     public const FACTORY_TEMPLATE = <<<'EOT'
         <?php
-        
+
         declare(strict_types=1);
-        
+
         namespace %s;
-        
+
         %s
-        
+
         class %sFactory implements FactoryInterface
         {
             /**
@@ -47,7 +47,7 @@ class FactoryCreator
                 return new %s(%s);
             }
         }
-        
+
         EOT;
 
     private const IMPORT_ALWAYS = [
@@ -135,9 +135,8 @@ class FactoryCreator
      */
     private function createArgumentString($className)
     {
-        $arguments = array_map(function (string $dependency): string {
-            return sprintf('$container->get(\\%s::class)', $dependency);
-        }, $this->getConstructorParameters($className));
+        $arguments = array_map(fn(string $dependency): string
+            => sprintf('$container->get(\\%s::class)', $dependency), $this->getConstructorParameters($className));
 
         switch (count($arguments)) {
             case 0:
@@ -160,8 +159,6 @@ class FactoryCreator
     {
         $imports = array_merge(self::IMPORT_ALWAYS, [$className]);
         sort($imports);
-        return implode("\n", array_map(function (string $import): string {
-            return sprintf('use %s;', $import);
-        }, $imports));
+        return implode("\n", array_map(fn(string $import): string => sprintf('use %s;', $import), $imports));
     }
 }

--- a/src/Tool/FactoryCreator.php
+++ b/src/Tool/FactoryCreator.php
@@ -159,6 +159,6 @@ class FactoryCreator
     {
         $imports = array_merge(self::IMPORT_ALWAYS, [$className]);
         sort($imports);
-        return implode("\n", array_map(fn(string $import): string => sprintf('use %s;', $import), $imports));
+        return implode("\n", array_map(static fn(string $import): string => sprintf('use %s;', $import), $imports));
     }
 }

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -301,7 +301,7 @@ class LazyServiceIntegrationTest extends TestCase
      */
     protected function getRegisteredProxyAutoloadFunctions()
     {
-        $filter = fn($autoload) => $autoload instanceof AutoloaderInterface;
+        $filter = fn($autoload): bool => $autoload instanceof AutoloaderInterface;
 
         return array_filter(spl_autoload_functions(), $filter);
     }

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -301,9 +301,7 @@ class LazyServiceIntegrationTest extends TestCase
      */
     protected function getRegisteredProxyAutoloadFunctions()
     {
-        $filter = function ($autoload) {
-            return $autoload instanceof AutoloaderInterface;
-        };
+        $filter = fn($autoload) => $autoload instanceof AutoloaderInterface;
 
         return array_filter(spl_autoload_functions(), $filter);
     }

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -301,7 +301,7 @@ class LazyServiceIntegrationTest extends TestCase
      */
     protected function getRegisteredProxyAutoloadFunctions()
     {
-        $filter = fn($autoload): bool => $autoload instanceof AutoloaderInterface;
+        $filter = static fn($autoload): bool => $autoload instanceof AutoloaderInterface;
 
         return array_filter(spl_autoload_functions(), $filter);
     }


### PR DESCRIPTION
@boesing we can skip Typed properties due BC Break, but for php 7.4 syntax like Arrow Function, Null coalescing assignment, I think we can apply it.