### PR TITLE
Conflict with `ext-psr`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "psr/container-implementation": "^1.0"
     },
     "conflict": {
+        "ext-psr": "*",
         "laminas/laminas-code": "<3.3.1",
         "zendframework/zend-code": "<3.3.1",
         "zendframework/zend-servicemanager": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e238a4c88ecd1972f68bc95830a9f920",
+    "content-hash": "aa071135de48212d7c9eba1a27bcbe1c",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -5431,5 +5431,5 @@
     "platform-overrides": {
         "php": "7.4.99"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | kinda
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | probably

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

There is a PHP extension around which provides all (most?) PSR interfaces without the need of installing them via composer. Since we do not support this extension and since that extension does not make sense anyways (more details later), we explicitly adding a `conflict` to the `composer.json` so that there are no surprises for projects which do have the `psr` extension installed.

closes #124

Now to the problem with the extension:

There are multiple PSR standards around. Many of them do have multiple major versions around. The extension has to follow semver to avoid breaks in upstream projects. So as of now (v1.2.0), it only provides the interfaces for the v1 versions of the PSR standards.
There is no way to provide multiple major versions of the same PSR interface from within one version of the extension.
Therefore, at some point, an upstream project is either stuck with the v1 versions of the PSR standards or the extension needs to create a hilarious amount of major versions to reflect all possible combinations of all major versions (cartesian product).

Lets just take the PSR-11 + PSR-6 example, we already would have 6 major versions around because PSR-11 has 2 major versions and PSR-6 has 3 major versions:

- psr/cache 1.x + psr/container 1.x
- psr/cache 1.x + psr/container 2.x
- psr/cache 2.x + psr/container 1.x
- psr/cache 2.x + psr/container 2.x
- psr/cache 3.x + psr/container 1.x
- psr/cache 3.x + psr/container 2.x

And these are only 2 packages. I lost track on the current progress, but there will be more major versions in the future and thus the amount of major versions for the extension will grow (and with that, the confusion for upstream projects, maintainers, etc.).

We highly recommend to use composer to install the PSR standards per package in the version the upstream project can work with.
**Do not use the `psr` extension**
