### PR TITLE
Fixed namespace generation in `FactoryCreator` utility

### DIFF
--- a/src/Tool/FactoryCreator.php
+++ b/src/Tool/FactoryCreator.php
@@ -16,10 +16,10 @@ use function array_merge;
 use function array_shift;
 use function count;
 use function implode;
+use function preg_replace;
 use function sort;
 use function sprintf;
 use function str_repeat;
-use function str_replace;
 use function strrpos;
 use function substr;
 
@@ -65,7 +65,7 @@ class FactoryCreator
 
         return sprintf(
             self::FACTORY_TEMPLATE,
-            str_replace('\\' . $class, '', $className),
+            preg_replace('/\\\\' . $class . '$/', '', $className),
             $this->createImportStatements($className),
             $class,
             $class,

--- a/test/Tool/FactoryCreatorTest.php
+++ b/test/Tool/FactoryCreatorTest.php
@@ -6,11 +6,14 @@ namespace LaminasTest\ServiceManager\Tool;
 
 use Laminas\ServiceManager\Tool\FactoryCreator;
 use LaminasTest\ServiceManager\TestAsset\ComplexDependencyObject;
+use LaminasTest\ServiceManager\TestAsset\Foo;
 use LaminasTest\ServiceManager\TestAsset\InvokableObject;
 use LaminasTest\ServiceManager\TestAsset\SimpleDependencyObject;
 use PHPUnit\Framework\TestCase;
 
+use function class_alias;
 use function file_get_contents;
+use function preg_match;
 
 class FactoryCreatorTest extends TestCase
 {
@@ -46,5 +49,21 @@ class FactoryCreatorTest extends TestCase
         $factory   = file_get_contents(__DIR__ . '/../TestAsset/factories/ComplexDependencyObject.php');
 
         $this->assertEquals($factory, $this->factoryCreator->createFactory($className));
+    }
+
+    public function testNamespaceGeneration(): void
+    {
+        $testClassNames = [
+            'Foo\\Bar\\Service'          => 'Foo\\Bar',
+            'Foo\\Service\\Bar\\Service' => 'Foo\\Service\\Bar',
+        ];
+        foreach ($testClassNames as $testFqcn => $expectedNamespace) {
+            class_alias(Foo::class, $testFqcn);
+            $generatedFactory = $this->factoryCreator->createFactory($testFqcn);
+            preg_match('/^namespace\s([^;]+)/m', $generatedFactory, $namespaceMatch);
+
+            $this->assertNotEmpty($namespaceMatch);
+            $this->assertEquals($expectedNamespace, $namespaceMatch[1]);
+        }
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

In FactoryCreator's createFactory method the namespace of the class has been built with `str_replace`. This method worked for this kind of classes: `Foo\Bar\Service`, but the generated namespace was wrong in case of this kind of classes: `Foo\Service\Bar\Service`, because namespace contains the class name too.

| FQCN | Generated namespace
|-|-
| Foo\Bar\Service | Foo\Bar
| Foo\Service\Bar\Service | Foo\Bar

With `preg_replace` it is possible to cut off only the last part of the FQCN.

