### PR TITLE
Update reflection based abstract factory documentation

### DIFF
--- a/docs/book/reflection-abstract-factory.md
+++ b/docs/book/reflection-abstract-factory.md
@@ -18,7 +18,7 @@ The factory operates with the following constraints/features:
 
 WARNING: `$options` passed to the factory are ignored in all cases, as we cannot make assumptions about which argument(s) they might replace.
 
-Once your dependencies have stabilized, we recommend writing a dedicated factory, as reflection can introduce performance overhead. 
+Once your dependencies have stabilized and when performance is a requirement, we recommend writing a dedicated factory, as reflection can introduce performance overhead. 
 For example, you could use the [generate-factory-for-class console tool](console-tools.md#generate-factory-for-class) to do so.
 
 ## Usage Example

--- a/docs/book/reflection-abstract-factory.md
+++ b/docs/book/reflection-abstract-factory.md
@@ -2,35 +2,24 @@
 
 - Since 3.2.0.
 
-Writing a factory class for each and every service that has dependencies
-can be tedious, particularly in early development as you are still sorting
-out dependencies.
+Writing a factory class for each and every service that has dependencies can be tedious, particularly in early development as you are still sorting out dependencies.
 
-To alleviate this issue during development, laminas-servicemanager ships with the [ReflectionBasedAbstractFactory](https://github.com/laminas/laminas-servicemanager/blob/3.12.x/src/AbstractFactory/ReflectionBasedAbstractFactory.php),
-which provides a [reflection-based approach](https://www.php.net/manual/en/intro.reflection.php) to instantiation, 
-resolving constructor dependencies to the relevant services. 
+To alleviate this issue during development, laminas-servicemanager ships with the `ReflectionBasedAbstractFactory`, which provides a [reflection-based approach](https://www.php.net/manual/en/intro.reflection.php) to instantiation, resolving constructor dependencies to the relevant services. 
 The factory may be used as either an abstract factory or mapped to specific service names as a factory.
 
 TIP: Mapping services to the factory is more explicit and performant.
 
 The factory operates with the following constraints/features:
 
-- A parameter named `$config` type-hinted as an array will receive the
-  application "config" service (i.e., the merged configuration).
-- Parameters type-hinted against array, but not named `$config`, will
-  be injected with an empty array.
-- Scalar parameters will result in the factory raising an exception,
-  unless a default value is present; if it is, that value will be used.
-- If a service cannot be found for a given typehint, the factory will
-  raise an exception detailing this.
+- A parameter named `$config` type-hinted as an array will receive the application "config" service (i.e., the merged configuration).
+- Parameters type-hinted against array, but not named `$config`, will be injected with an empty array.
+- Scalar parameters will result in the factory raising an exception, unless a default value is present; if it is, that value will be used.
+- If a service cannot be found for a given typehint, the factory will raise an exception detailing this.
 
-WARNING: `$options` passed to the factory are ignored in all cases, as we cannot make assumptions about which 
-argument(s) they might replace.
+WARNING: `$options` passed to the factory are ignored in all cases, as we cannot make assumptions about which argument(s) they might replace.
 
-Once your dependencies have stabilized, we recommend writing a dedicated
-factory, as reflection can introduce performance overhead. For example, you could use the
-[generate-factory-for-class console tool](console-tools.md#generate-factory-for-class)
-to do so.
+Once your dependencies have stabilized, we recommend writing a dedicated factory, as reflection can introduce performance overhead. 
+For example, you could use the [generate-factory-for-class console tool](console-tools.md#generate-factory-for-class) to do so.
 
 ## Usage Example
 
@@ -85,8 +74,8 @@ public function getDependencies(): array
 
 ## Handling well-known services
 
-Some services provided by Laminas components do not have
-entries based on their class name (for historical reasons). As examples:
+Some services provided by Laminas components do not have entries based on their class name (for historical reasons). 
+As examples:
 
 - `Laminas\Console\Adapter\AdapterInterface` maps to the service name `ConsoleAdapter`,
 - `Laminas\Filter\FilterPluginManager` maps to the service name `FilterManager`,
@@ -99,8 +88,7 @@ entries based on their class name (for historical reasons). As examples:
 - `Laminas\Serializer\AdapterPluginManager` maps to the service name `SerializerAdapterManager`,
 - `Laminas\Validator\ValidatorPluginManager` maps to the service name `ValidatorManager`,
 
-To allow the `ReflectionBasedAbstractFactory` to find these, you have two
-options.
+To allow the `ReflectionBasedAbstractFactory` to find these, you have two options.
 
 The first is to pass an array of mappings via the constructor:
 
@@ -119,12 +107,9 @@ $reflectionFactory = new ReflectionBasedAbstractFactory([
 ]);
 ```
 
-This can be done either in your configuration file (which could be problematic
-when considering serialization for caching), or during an early phase of
-application bootstrapping.
+This can be done either in your configuration file (which could be problematic when considering serialization for caching), or during an early phase of application bootstrapping.
 
-For instance, with laminas-mvc, this might be in your `Application` module's
-bootstrap listener:
+For instance, with laminas-mvc, this might be in your `Application` module's bootstrap listener:
 
 ```php
 namespace Application
@@ -156,8 +141,7 @@ $container->addAbstractFactory(new ReflectionBasedAbstractFactory([
 ]));
 ```
 
-The second approach is to extend the class, and define the map in the
-`$aliases` property:
+The second approach is to extend the class, and define the map in the `$aliases` property:
 
 ```php
 namespace Application;
@@ -185,15 +169,11 @@ You could then register it via class name in your service configuration.
 
 ## Alternatives
 
-You may also use the [Config Abstract Factory](config-abstract-factory.md),
-which gives slightly more flexibility in terms of mapping dependencies:
+You may also use the [Config Abstract Factory](config-abstract-factory.md), which gives slightly more flexibility in terms of mapping dependencies:
 
-- If you wanted to map to a specific implementation, choose the
-  `ConfigAbstractFactory`.
-- If you need to map to a service that will return a scalar or array (e.g., a
-  subset of the `'config'` service), choose the `ConfigAbstractFactory`.
-- If you need a faster factory for production, choose the
-  `ConfigAbstractFactory` or create a custom factory.
+- If you wanted to map to a specific implementation, choose the `ConfigAbstractFactory`.
+- If you need to map to a service that will return a scalar or array (e.g., a subset of the `'config'` service), choose the `ConfigAbstractFactory`.
+- If you need a faster factory for production, choose the `ConfigAbstractFactory` or create a custom factory.
 
 ## References
 

--- a/docs/book/reflection-abstract-factory.md
+++ b/docs/book/reflection-abstract-factory.md
@@ -6,10 +6,40 @@ Writing a factory class for each and every service that has dependencies
 can be tedious, particularly in early development as you are still sorting
 out dependencies.
 
-laminas-servicemanager ships with `Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory`,
-which provides a reflection-based approach to instantiation, resolving
-constructor dependencies to the relevant services. The factory may be used as
-either an abstract factory, or mapped to specific service names as a factory:
+To alleviate this issue during development, laminas-servicemanager ships with the [ReflectionBasedAbstractFactory](https://github.com/laminas/laminas-servicemanager/blob/3.12.x/src/AbstractFactory/ReflectionBasedAbstractFactory.php),
+which provides a [reflection-based approach](https://www.php.net/manual/en/intro.reflection.php) to instantiation, 
+resolving constructor dependencies to the relevant services. 
+The factory may be used as either an abstract factory or mapped to specific service names as a factory.
+
+TIP: Mapping services to the factory is more explicit and performant.
+
+The factory operates with the following constraints/features:
+
+- A parameter named `$config` type-hinted as an array will receive the
+  application "config" service (i.e., the merged configuration).
+- Parameters type-hinted against array, but not named `$config`, will
+  be injected with an empty array.
+- Scalar parameters will result in the factory raising an exception,
+  unless a default value is present; if it is, that value will be used.
+- If a service cannot be found for a given typehint, the factory will
+  raise an exception detailing this.
+
+WARNING: `$options` passed to the factory are ignored in all cases, as we cannot make assumptions about which 
+argument(s) they might replace.
+
+Once your dependencies have stabilized, we recommend writing a dedicated
+factory, as reflection can introduce performance overhead. For example, you could use the
+[generate-factory-for-class console tool](console-tools.md#generate-factory-for-class)
+to do so.
+
+## Usage Example
+
+### Using Laminas MVC
+
+When using [Laminas MVC](https://docs.laminas.dev/mvc/):
+
+- Add the factory in the service manager's list of abstract factories.
+- Use the `ReflectionBasedAbstractFactory` to instantiate the class.
 
 ```php
 use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
@@ -28,26 +58,30 @@ return [
 ];
 ```
 
-Mapping services to the factory is more explicit and performant.
 
-The factory operates with the following constraints/features:
+### Using Mezzio
 
-- A parameter named `$config` typehinted as an array will receive the
-  application "config" service (i.e., the merged configuration).
-- Parameters typehinted against array, but not named `$config`, will
-  be injected with an empty array.
-- Scalar parameters will result in the factory raising an exception,
-  unless a default value is present; if it is, that value will be used.
-- If a service cannot be found for a given typehint, the factory will
-  raise an exception detailing this.
+In a module's [ConfigProvider](https://docs.laminas.dev/laminas-config-aggregator/config-providers/) class:
 
-`$options` passed to the factory are ignored in all cases, as we cannot
-make assumptions about which argument(s) they might replace.
+- Add the `ReflectionBasedAbstractFactory` to the `abstract_factories` array returned from the `getDependencies()` method.
+- Use the `ReflectionBasedAbstractFactory` to instantiate the class, in the `factories` array returned from the `getDependencies()` method.
 
-Once your dependencies have stabilized, we recommend writing a dedicated
-factory, as reflection can introduce performance overhead; you may use the
-[generate-factory-for-class console tool](console-tools.md#generate-factory-for-class)
-to do so.
+```php
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+
+public function getDependencies(): array
+{
+    return [
+        'abstract_factories' => [
+            ReflectionBasedAbstractFactory::class,
+        ],
+        'factories' => [
+            // Other factories...
+            Handler\HomePageHandler::class => ReflectionBasedAbstractFactory::class,
+        ],
+    ],
+}
+```
 
 ## Handling well-known services
 


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

After working through the documentation to learn more about the Reflection-based Abstract Factor, I felt that the documentation could be refined to make it that much easier to read and maintain, as well as to extend the usage examples to make them more encompassing of different use cases. This PR replaces https://github.com/laminas/laminas-servicemanager/pull/134.