### PR TITLE
Skip `class_alias()` declarations when interfaces were already declared, allowing for usage with preloading

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,5 +1,6 @@
 <?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid
 
+
 declare(strict_types=1);
 
 use Interop\Container\Containerinterface as InteropContainerInterface;
@@ -9,12 +10,12 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-if (!interface_exists(InteropContainerInterface::class, false)) {
+if (! interface_exists(InteropContainerInterface::class, false)) {
     class_alias(ContainerInterface::class, InteropContainerInterface::class);
 }
-if (!interface_exists(InteropContainerException::class, false)) {
+if (! interface_exists(InteropContainerException::class, false)) {
     class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
 }
-if (!interface_exists(InteropNotFoundException::class, false)) {
+if (! interface_exists(InteropNotFoundException::class, false)) {
     class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);
 }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,6 +1,5 @@
 <?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid
 
-
 declare(strict_types=1);
 
 use Interop\Container\Containerinterface as InteropContainerInterface;
@@ -10,6 +9,12 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-class_alias(ContainerInterface::class, InteropContainerInterface::class);
-class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
-class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);
+if (!interface_exists(InteropContainerInterface::class, false)) {
+    class_alias(ContainerInterface::class, InteropContainerInterface::class);
+}
+if (!interface_exists(InteropContainerException::class, false)) {
+    class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
+}
+if (!interface_exists(InteropNotFoundException::class, false)) {
+    class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);
+}


### PR DESCRIPTION
Signed-off-by: Lucas Hantz <lucas.hantz@gmail.com>

Fixes #128 
Closes #143 
