### PR TITLE
Allow usage with opcache preloading by preventing double-loading of `container-interop` interfaces

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -10,6 +10,13 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-class_alias(ContainerInterface::class, InteropContainerInterface::class);
-class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
-class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);
+if (!interface_exists(InteropContainerInterface::class, false)) {
+    class_alias(ContainerInterface::class, InteropContainerInterface::class);
+}
+if (!interface_exists(InteropContainerException::class, false)) {
+    class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
+}
+
+if (!interface_exists(InteropNotFoundException::class, false)) {
+    class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);
+}


### PR DESCRIPTION
(Replaces #129 as I somehow closed that PR)
---
Fixes #128 

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Not sure how to test this, except the manual tests I ran. 
