### PR TITLE
Relax templated parameters for the plugin manager

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -27,7 +27,6 @@
     </LessSpecificReturnStatement>
     <MissingClosureReturnType occurrences="1">
       <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
-      <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
     </MissingClosureReturnType>
     <MissingParamType occurrences="1">
       <code>$requestedName</code>
@@ -53,9 +52,15 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/AbstractPluginManager.php">
+    <ImplementedParamTypeMismatch occurrences="1">
+      <code>$service</code>
+    </ImplementedParamTypeMismatch>
     <MissingReturnType occurrences="1">
       <code>setService</code>
     </MissingReturnType>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$service</code>
+    </MixedArgumentTypeCoercion>
     <ParamNameMismatch occurrences="1">
       <code>$name</code>
     </ParamNameMismatch>
@@ -110,9 +115,7 @@
     <MixedArgument occurrences="5">
       <code>$abstractFactory</code>
       <code>$config['delegators']</code>
-      <code>$config['delegators']</code>
       <code>$config['initializers']</code>
-      <code>$config['invokables']</code>
       <code>$config['invokables']</code>
       <code>$config['lazy_services']</code>
     </MixedArgument>
@@ -325,7 +328,6 @@
     </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$instance</code>
-      <code>$instance</code>
     </MixedAssignment>
     <MixedFunctionCall occurrences="1">
       <code>$callback()</code>
@@ -360,21 +362,17 @@
     </InvalidArrayOffset>
     <MissingClosureParamType occurrences="10">
       <code>$callback</code>
-      <code>$callback</code>
       <code>$className</code>
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
-      <code>$container</code>
       <code>$instance</code>
       <code>$instance</code>
-      <code>$name</code>
       <code>$name</code>
       <code>$requestedName</code>
     </MissingClosureParamType>
     <MissingClosureReturnType occurrences="2">
-      <code>function ($container, $name, $callback) {</code>
       <code>function ($container, $name, $callback) {</code>
       <code>function ($container, $requestedName, ?array $options = null) {</code>
     </MissingClosureReturnType>
@@ -411,7 +409,6 @@
       <code>$idx1</code>
       <code>$idx2</code>
       <code>$instance</code>
-      <code>$instance</code>
       <code>$lazyServices</code>
       <code>$method</code>
       <code>$name</code>
@@ -423,8 +420,6 @@
       <code>$object1</code>
       <code>$object1</code>
       <code>$object1</code>
-      <code>$object1</code>
-      <code>$object2</code>
       <code>$object2</code>
       <code>$object2</code>
       <code>$object2</code>
@@ -436,7 +431,6 @@
     </MixedAssignment>
     <MixedFunctionCall occurrences="1">
       <code>$callback()</code>
-      <code>$callback()</code>
     </MixedFunctionCall>
     <MixedInferredReturnType occurrences="6">
       <code>array</code>
@@ -447,7 +441,6 @@
       <code>array</code>
     </MixedInferredReturnType>
     <MixedPropertyAssignment occurrences="1">
-      <code>$instance</code>
       <code>$instance</code>
     </MixedPropertyAssignment>
     <PossiblyUndefinedVariable occurrences="5">
@@ -536,7 +529,6 @@
       <code>$name</code>
       <code>$name</code>
       <code>$name</code>
-      <code>$name</code>
     </MissingClosureParamType>
     <MissingClosureReturnType occurrences="2">
       <code>function (</code>
@@ -553,7 +545,6 @@
       <code>$headAlias</code>
       <code>$inc</code>
       <code>$inc</code>
-      <code>$instance</code>
       <code>$instance</code>
       <code>$instance1</code>
       <code>$instance1</code>

--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -32,7 +32,7 @@ use const E_USER_DEPRECATED;
  * The implementation extends `ServiceManager`, thus providing the same set
  * of capabilities as found in that implementation.
  *
- * @template InstanceType of object
+ * @template InstanceType
  * @implements PluginManagerInterface<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @psalm-suppress PropertyNotSetInConstructor
@@ -136,7 +136,6 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
      *
      * @param string|class-string<InstanceType> $name
      * @param InstanceType $service
-     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function setService($name, $service)
     {

--- a/src/PluginManagerInterface.php
+++ b/src/PluginManagerInterface.php
@@ -12,7 +12,7 @@ use Psr\Container\ContainerExceptionInterface;
  *
  * A plugin manager is a specialized service locator used to create homogeneous objects
  *
- * @template InstanceType of object
+ * @template InstanceType
  */
 interface PluginManagerInterface extends ServiceLocatorInterface
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Not all implementations return objects and being too strict here causes problems downstream.

Note: psalm errors raised in AbstractPluginManager::setService() have been baselined because otherwise, the whole of ServiceManager will need to be templated too.
