### PR TITLE
WIP: Make `AbstractPluginManager#get()` retrieve `InstanceType` for non-`class-string` input

### DIFF
--- a/src/AbstractPluginManager.php
+++ b/src/AbstractPluginManager.php
@@ -143,10 +143,11 @@ abstract class AbstractPluginManager extends ServiceManager implements PluginMan
     }
 
     /**
-     * @param class-string<InstanceType>|string $name Service name of plugin to retrieve.
+     * @template RequestedType of object
+     * @param class-string<RequestedType>|string $name Service name of plugin to retrieve.
      * @param null|array<mixed> $options Options to use when creating the instance.
      * @return mixed
-     * @psalm-return ($name is class-string<InstanceType> ? InstanceType : mixed)
+     * @psalm-return ($name is class-string<RequestedType> ? (RequestedType&InstanceType) : InstanceType)
      * @throws Exception\ServiceNotFoundException If the manager does not have
      *     a service definition for the instance, and the service is not
      *     auto-invokable.

--- a/test/StaticAnalysis/AbstractPluginManager.php
+++ b/test/StaticAnalysis/AbstractPluginManager.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ServiceManager\StaticAnalysis;
+
+use Laminas\ServiceManager\AbstractPluginManager as PluginManager;
+use LaminasTest\ServiceManager\TestAsset\Foo;
+use stdClass;
+
+final class AbstractPluginManager
+{
+    /** @param PluginManager<Foo|stdClass> $pluginManager */
+    public function pluginManagerRetrievesDefaultType(PluginManager $pluginManager): Foo|stdClass
+    {
+        return $pluginManager->get('unknown-type-will-result-in-plugin-manager-default-type');
+    }
+
+    /** @param PluginManager<Foo|stdClass> $pluginManager */
+    public function pluginManagerRetrievesRequestedFooType(PluginManager $pluginManager): Foo
+    {
+        return $pluginManager->get(Foo::class);
+    }
+
+    /** @param PluginManager<Foo|stdClass> $pluginManager */
+    public function pluginManagerRetrievesRequestedStdClassType(PluginManager $pluginManager): stdClass
+    {
+        return $pluginManager->get(stdClass::class);
+    }
+
+    /**
+     * @see https://github.com/vimeo/psalm/issues/8815
+     *
+     * @param PluginManager<Foo|stdClass> $pluginManager
+     * @psalm-suppress TypeDoesNotContainType this type suppression should be valid.
+     */
+    public function pluginManagerCannotRetrieveImpossibleType(PluginManager $pluginManager): self
+    {
+        return $pluginManager->get(self::class);
+    }
+}


### PR DESCRIPTION
This change makes it so that `AbstractPluginManager#get(string): InstanceType` is always produced: since the plugin manager validates each retrieved instance, the type can safely be assumed to **NOT** be `mixed`.

This should improve overall type inference across our components.

Also, this should invalidate calls such as `AbstractPluginManager#get(NotAPlugin::class)`, since the `NotAPlugin&InstanceType` will result in an impossible type anyway.

Note: this entire feature depends on https://github.com/vimeo/psalm/issues/8815. Without
      implementing https://github.com/vimeo/psalm/issues/8815 first, we cannot proceed, as
      downstream consumers will otherwise be able to request any `class-string<T>` to the
      plugin manager system!


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no
