### PR TITLE
Allow psr/container 2.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-stdlib": "^3.2.1",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0|^2.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11.99.5",

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -269,7 +269,7 @@ class ServiceManager implements ServiceLocatorInterface
      * @param string|class-string $name
      * @return bool
      */
-    public function has($name)
+    public function has($name): bool
     {
         // Check static services and factories first to speedup the most common requests.
         return $this->staticServiceOrFactoryCanCreate($name) || $this->abstractFactoryCanCreate($name);


### PR DESCRIPTION
Should allow psr/container 2.0.2 - not only 1.1.2

Changes:
https://github.com/php-fig/container/compare/2.0.2...1.1.2

Can close after merge: https://github.com/laminas/laminas-servicemanager/pull/151


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
