### PR TITLE
Remove deprecated `ServiceManager#getServiceLocator` method

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -32,9 +32,6 @@ use function is_string;
 use function spl_autoload_register;
 use function spl_object_hash;
 use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Service Manager.
@@ -175,25 +172,6 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $this->creationContext = $this;
         $this->configure($config);
-    }
-
-    /**
-     * Implemented for backwards compatibility with previous plugin managers only.
-     *
-     * Returns the creation context.
-     *
-     * @deprecated since 3.0.0. Factories using 3.0 should use the container
-     *     instance passed to the factory instead.
-     *
-     * @return ContainerInterface
-     */
-    public function getServiceLocator()
-    {
-        trigger_error(sprintf(
-            'Usage of %s is deprecated since v3.0.0; please use the container passed to the factory instead',
-            __METHOD__
-        ), E_USER_DEPRECATED);
-        return $this->creationContext;
     }
 
     /** {@inheritDoc} */

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -36,10 +36,6 @@ use function array_keys;
 use function array_merge;
 use function PHPUnit\Framework\assertIsBool;
 use function PHPUnit\Framework\assertIsString;
-use function restore_error_handler;
-use function set_error_handler;
-
-use const E_USER_DEPRECATED;
 
 /**
  * @see ConfigInterface
@@ -934,21 +930,6 @@ trait CommonServiceLocatorBehaviorsTrait
         $container->setAllowOverride(true);
 
         self::assertTrue($container->getAllowOverride());
-    }
-
-    /**
-     * @group migration
-     */
-    public function testCanRetrieveParentContainerViaGetServiceLocatorWithDeprecationNotice(): void
-    {
-        $container = $this->createContainer();
-        set_error_handler(static function (int $errno): bool {
-            self::assertEquals(E_USER_DEPRECATED, $errno);
-
-            return true;
-        }, E_USER_DEPRECATED);
-        self::assertSame($this->creationContext, $container->getServiceLocator());
-        restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Removes deprecated `ServiceManager#getServiceLocator` method.