### PR TITLE
Drop PHP 8.0 support, replace `ocramius/proxy-manager` with `friendsofphp/proxy-manager-lts`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,72 +13,78 @@
     ],
     "homepage": "https://laminas.dev",
     "support": {
-        "docs": "https://docs.laminas.dev/laminas-servicemanager/",
         "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-        "source": "https://github.com/laminas/laminas-servicemanager",
-        "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+        "forum": "https://discourse.laminas.dev",
         "chat": "https://laminas.dev/chat",
-        "forum": "https://discourse.laminas.dev"
-    },
-    "config": {
-        "platform": {
-            "php": "8.0.99"
-        },
-        "sort-packages": true,
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/package-versions-deprecated": true,
-            "laminas/laminas-dependency-plugin": true
-        }
+        "source": "https://github.com/laminas/laminas-servicemanager",
+        "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+        "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom"
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-        "laminas/laminas-stdlib": "^3.2.1",
+        "php": "~8.1.0 || ~8.2.0",
+        "laminas/laminas-stdlib": "^3.17",
         "psr/container": "^1.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11.99.5",
+        "friendsofphp/proxy-manager-lts": "^1.0.14",
+        "laminas/laminas-code": "^4.10.0",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-container-config-test": "^0.8",
         "laminas/laminas-dependency-plugin": "^2.2",
-        "mikey179/vfsstream": "^1.6.11@alpha",
-        "ocramius/proxy-manager": "^2.14.1",
-        "phpbench/phpbench": "^1.2.7",
-        "phpunit/phpunit": "^9.5.26",
-        "psalm/plugin-phpunit": "^0.18.0",
-        "vimeo/psalm": "^5.0.0"
+        "mikey179/vfsstream": "^1.6.11",
+        "phpbench/phpbench": "^1.2.9",
+        "phpunit/phpunit": "^9.6.5",
+        "psalm/plugin-phpunit": "^0.18.4",
+        "vimeo/psalm": "^5.8.0"
+    },
+    "replace": {
+        "container-interop/container-interop": "^1.2.0"
+    },
+    "conflict": {
+        "ext-psr": "*",
+        "laminas/laminas-code": "<4.10.0",
+        "zendframework/zend-code": "<3.3.1",
+        "zendframework/zend-servicemanager": "*"
     },
     "provide": {
         "psr/container-implementation": "^1.0"
     },
-    "conflict": {
-        "ext-psr": "*",
-        "laminas/laminas-code": "<3.3.1",
-        "zendframework/zend-code": "<3.3.1",
-        "zendframework/zend-servicemanager": "*"
-    },
     "suggest": {
-        "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+        "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
     },
     "autoload": {
         "psr-4": {
             "Laminas\\ServiceManager\\": "src/"
         },
-        "files": ["src/autoload.php"]
+        "files": [
+            "src/autoload.php"
+        ]
     },
     "autoload-dev": {
-        "files": [
-            "test/autoload.php"
-        ],
         "psr-4": {
             "LaminasTest\\ServiceManager\\": "test/",
             "LaminasBench\\ServiceManager\\": "benchmarks/"
-        }
+        },
+        "files": [
+            "test/autoload.php"
+        ]
     },
     "bin": [
         "bin/generate-deps-for-config-factory",
         "bin/generate-factory-for-class"
     ],
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true,
+            "laminas/laminas-dependency-plugin": true
+        },
+        "platform": {
+            "php": "8.1.99"
+        },
+        "sort-packages": true
+    },
     "scripts": {
         "benchmark": "phpbench run --revs=2 --iterations=2 --report=aggregate",
         "check": [
@@ -87,11 +93,8 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-        "static-analysis" : "psalm --shepherd --stats"
-    },
-    "replace": {
-        "container-interop/container-interop": "^1.2.0"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "949c8e2ab94d6fa0abb925a43ffd0035",
+    "content-hash": "ff2c862b21fe405bd33aef99e6fd5678",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -63,7 +63,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "psr/container",
@@ -686,30 +686,30 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.14.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "9e034d7a70032d422169f27d8759e8d84abb4f51"
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/9e034d7a70032d422169f27d8759e8d84abb4f51",
-                "reference": "9e034d7a70032d422169f27d8759e8d84abb4f51",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1 || ^2",
+                "doctrine/lexer": "^2 || ^3",
                 "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "~1.4.10 || ^1.8.0",
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/cache": "^5.4 || ^6",
                 "vimeo/psalm": "^4.10"
             },
             "suggest": {
@@ -756,79 +756,36 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.14.1"
+                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
             },
-            "time": "2022-12-12T12:46:12+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1|^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
-            },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-02-02T22:02:53+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -855,7 +812,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -871,32 +828,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "2.1.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/84a527db05647743d50373e0ec53a152f2cde568",
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568",
                 "shasum": ""
             },
             "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^9.5",
                 "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
+                "vimeo/psalm": "^5.0"
             },
             "type": "library",
             "autoload": {
@@ -933,7 +889,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "source": "https://github.com/doctrine/lexer/tree/3.0.0"
             },
             "funding": [
                 {
@@ -949,7 +905,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2022-12-15T16:57:16+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1054,16 +1010,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1103,7 +1059,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1111,33 +1067,115 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
-            "name": "laminas/laminas-code",
-            "version": "4.7.1",
+            "name": "friendsofphp/proxy-manager-lts",
+            "version": "v1.0.14",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "91aabc066d5620428120800c0eafc0411e441a62"
+                "url": "https://github.com/FriendsOfPHP/proxy-manager-lts.git",
+                "reference": "a527c9d9d5348e012bd24482d83a5cd643bcbc9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/91aabc066d5620428120800c0eafc0411e441a62",
-                "reference": "91aabc066d5620428120800c0eafc0411e441a62",
+                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/a527c9d9d5348e012bd24482d83a5cd643bcbc9e",
+                "reference": "a527c9d9d5348e012bd24482d83a5cd643bcbc9e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4, <8.2"
+                "laminas/laminas-code": "~3.4.1|^4.0",
+                "php": ">=7.1",
+                "symfony/filesystem": "^4.4.17|^5.0|^6.0"
+            },
+            "conflict": {
+                "laminas/laminas-stdlib": "<3.2.1",
+                "zendframework/zend-stdlib": "<3.2.1"
+            },
+            "replace": {
+                "ocramius/proxy-manager": "^2.1"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13.2",
+                "ext-phar": "*",
+                "symfony/phpunit-bridge": "^5.4|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "ocramius/proxy-manager",
+                    "url": "https://github.com/Ocramius/ProxyManager"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ProxyManager\\": "src/ProxyManager"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                }
+            ],
+            "description": "Adding support for a wider range of PHP versions to ocramius/proxy-manager",
+            "homepage": "https://github.com/FriendsOfPHP/proxy-manager-lts",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "support": {
+                "issues": "https://github.com/FriendsOfPHP/proxy-manager-lts/issues",
+                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/proxy-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-30T10:40:19+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "4.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/ad8b36073f9ac792716478befadca0798cc15635",
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0.0",
                 "ext-phar": "*",
                 "laminas/laminas-coding-standard": "^2.3.0",
                 "laminas/laminas-stdlib": "^3.6.1",
-                "phpunit/phpunit": "^9.5.10",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.13.1"
+                "phpunit/phpunit": "^10.0.9",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.7.1"
             },
             "suggest": {
                 "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
@@ -1145,9 +1183,6 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "polyfill/ReflectionEnumPolyfill.php"
-                ],
                 "psr-4": {
                     "Laminas\\Code\\": "src/"
                 }
@@ -1177,7 +1212,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-21T01:32:31+00:00"
+            "time": "2023-03-08T11:55:01+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1408,16 +1443,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1455,7 +1490,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1463,7 +1498,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1518,16 +1553,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.2",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -1568,143 +1603,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2022-11-12T15:38:23+00:00"
-        },
-        {
-            "name": "ocramius/proxy-manager",
-            "version": "2.14.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "3990d60ef79001badbab4927a6a811682274a0d1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/3990d60ef79001badbab4927a6a811682274a0d1",
-                "reference": "3990d60ef79001badbab4927a6a811682274a0d1",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.1.0",
-                "laminas/laminas-code": "^4.4.2",
-                "php": "~8.0.0",
-                "webimpress/safe-writer": "^2.2.0"
-            },
-            "conflict": {
-                "thecodingmachine/safe": "<1.3.3"
-            },
-            "require-dev": {
-                "codelicia/xulieta": "^0.1.6",
-                "doctrine/coding-standard": "^9.0.0",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.0.3",
-                "phpunit/phpunit": "^9.5.6",
-                "roave/infection-static-analysis-plugin": "^1.8",
-                "squizlabs/php_codesniffer": "^3.6.0",
-                "vimeo/psalm": "^4.8.1"
-            },
-            "suggest": {
-                "laminas/laminas-json": "To have the JsonRpc adapter (Remote Object feature)",
-                "laminas/laminas-soap": "To have the Soap adapter (Remote Object feature)",
-                "laminas/laminas-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)",
-                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ProxyManager\\": "src/ProxyManager"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
-            "homepage": "https://github.com/Ocramius/ProxyManager",
-            "keywords": [
-                "aop",
-                "lazy loading",
-                "proxy",
-                "proxy pattern",
-                "service proxies"
-            ],
-            "support": {
-                "issues": "https://github.com/Ocramius/ProxyManager/issues",
-                "source": "https://github.com/Ocramius/ProxyManager/tree/2.14.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Ocramius",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ocramius/proxy-manager",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-03-05T18:43:14+00:00"
-        },
-        {
-            "name": "openlss/lib-array2xml",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nullivex/lib-array2xml.git",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "LSS": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Bryan Tong",
-                    "email": "bryan@nullivex.com",
-                    "homepage": "https://www.nullivex.com"
-                },
-                {
-                    "name": "Tony Butler",
-                    "email": "spudz76@gmail.com",
-                    "homepage": "https://www.nullivex.com"
-                }
-            ],
-            "description": "Array2XML conversion library credit to lalit.org",
-            "homepage": "https://www.nullivex.com",
-            "keywords": [
-                "array",
-                "array conversion",
-                "xml",
-                "xml conversion"
-            ],
-            "support": {
-                "issues": "https://github.com/nullivex/lib-array2xml/issues",
-                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
-            },
-            "time": "2019-03-29T20:06:56+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1870,25 +1771,25 @@
         },
         {
             "name": "phpbench/dom",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/dom.git",
-                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110"
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/dom/zipball/b013b717832ddbaadf2a40984b04bc66af9a7110",
-                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/786a96db538d0def931f5b19225233ec42ec7a72",
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.2||^8.0"
+                "php": "^7.3||^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.18",
-                "phpstan/phpstan": "^0.12.83",
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^8.0||^9.0"
             },
             "type": "library",
@@ -1915,35 +1816,35 @@
             "description": "DOM wrapper to simplify working with the PHP DOM implementation",
             "support": {
                 "issues": "https://github.com/phpbench/dom/issues",
-                "source": "https://github.com/phpbench/dom/tree/0.3.2"
+                "source": "https://github.com/phpbench/dom/tree/0.3.3"
             },
-            "time": "2021-09-24T15:26:07+00:00"
+            "time": "2023-03-06T23:46:57+00:00"
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.2.7",
+            "version": "1.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "dce145304abbb16c8d9af69c19d96f47e9d0e670"
+                "reference": "7aaea137809603b1c4f46d1790ba0f009be15797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/dce145304abbb16c8d9af69c19d96f47e9d0e670",
-                "reference": "dce145304abbb16c8d9af69c19d96f47e9d0e670",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/7aaea137809603b1c4f46d1790ba0f009be15797",
+                "reference": "7aaea137809603b1c4f46d1790ba0f009be15797",
                 "shasum": ""
             },
             "require": {
-                "doctrine/annotations": "^1.13",
+                "doctrine/annotations": "^1.13 || ^2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "ext-tokenizer": "*",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpbench/container": "^2.1",
-                "phpbench/dom": "~0.3.1",
+                "phpbench/dom": "~0.3.3",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
                 "seld/jsonlint": "^1.1",
                 "symfony/console": "^4.2 || ^5.0  || ^6.0",
@@ -1961,7 +1862,7 @@
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^8.5.8 || ^9.0",
+                "phpunit/phpunit": "^9.0",
                 "symfony/error-handler": "^5.2 || ^6.0",
                 "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0"
             },
@@ -1999,7 +1900,7 @@
             "description": "PHP Benchmarking Framework",
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.2.7"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.9"
             },
             "funding": [
                 {
@@ -2007,7 +1908,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-15T09:57:51+00:00"
+            "time": "2023-03-08T08:56:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2220,23 +2121,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.21",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2251,8 +2152,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -2285,7 +2186,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -2293,7 +2194,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-14T13:26:54+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2538,20 +2439,20 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.27",
+            "version": "9.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
+                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2580,8 +2481,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -2589,7 +2490,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -2620,7 +2521,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
             },
             "funding": [
                 {
@@ -2636,7 +2537,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-09T07:31:23+00:00"
+            "time": "2023-03-09T06:34:10+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3163,16 +3064,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -3214,7 +3115,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -3222,7 +3123,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3536,16 +3437,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -3584,10 +3485,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3595,7 +3496,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3654,16 +3555,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3698,7 +3599,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3706,7 +3607,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3887,17 +3788,80 @@
             "time": "2022-05-25T10:58:12+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "name": "spatie/array-to-xml",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-24T13:43:51+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -3933,31 +3897,33 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.16",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "be294423f337dda97c810733138c0caec1bb0575"
+                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/be294423f337dda97c810733138c0caec1bb0575",
-                "reference": "be294423f337dda97c810733138c0caec1bb0575",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
+                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -4019,7 +3985,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.16"
+                "source": "https://github.com/symfony/console/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4035,29 +4001,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T18:58:46+00:00"
+            "time": "2023-02-25T17:00:03+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4086,7 +4052,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4102,24 +4068,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.13",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79"
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3adca49133bd055ebe6011ed1e012be3c908af79",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/82b6c62b959f642d000456f08c6d219d749215b3",
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -4149,7 +4115,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.13"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4165,24 +4131,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-21T20:25:27+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.11",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1"
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/09cb683ba5720385ea6966e5e06be2a34f2568b1",
-                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4210,7 +4179,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.11"
+                "source": "https://github.com/symfony/finder/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4226,24 +4195,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T07:39:48+00:00"
+            "time": "2023-02-16T09:57:23+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.0.3",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d"
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/51f7006670febe4cbcbae177cbffe93ff833250d",
-                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/aa0e85b53bbb2b4951960efd61d295907eacd629",
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.1|^3"
             },
             "type": "library",
@@ -4277,7 +4246,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.0.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4293,7 +4262,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4626,104 +4595,21 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/process",
-            "version": "v6.0.11",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43"
+                "reference": "680e8a2ea6b3f87aecc07a6a65a203ae573d1902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43",
-                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43",
+                "url": "https://api.github.com/repos/symfony/process/zipball/680e8a2ea6b3f87aecc07a6a65a203ae573d1902",
+                "reference": "680e8a2ea6b3f87aecc07a6a65a203ae573d1902",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -4751,7 +4637,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.11"
+                "source": "https://github.com/symfony/process/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4767,7 +4653,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-27T17:10:44+00:00"
+            "time": "2023-02-24T10:42:00+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4854,20 +4740,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.15",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771"
+                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/51ac0fa0ccf132a00519b87c97e8f775fa14e771",
-                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771",
+                "url": "https://api.github.com/repos/symfony/string/zipball/67b8c1eec78296b85dc1c7d9743830160218993d",
+                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4879,6 +4765,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -4919,7 +4806,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.15"
+                "source": "https://github.com/symfony/string/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4935,7 +4822,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-10T09:34:08+00:00"
+            "time": "2023-02-24T10:42:00+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4989,22 +4876,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.2.0",
+            "version": "5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba"
+                "reference": "9cf4f60a333f779ad3bc704a555920e81d4fdcda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fb685a16df3050d4c18d8a4100fe83abe6458cba",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9cf4f60a333f779ad3bc704a555920e81d4fdcda",
+                "reference": "9cf4f60a333f779ad3bc704a555920e81d4fdcda",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -5017,28 +4904,27 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
-                "openlss/lib-array2xml": "^1.0",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-                "sebastian/diff": "^4.0",
+                "sebastian/diff": "^4.0 || ^5.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/polyfill-php80": "^1.25"
+                "symfony/filesystem": "^5.4 || ^6.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -5084,34 +4970,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.2.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.8.0"
             },
-            "time": "2022-12-12T08:18:56+00:00"
+            "time": "2023-03-09T04:14:35+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5137,7 +5024,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5145,66 +5032,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
-        },
-        {
-            "name": "webimpress/safe-writer",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/safe-writer.git",
-                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/safe-writer/zipball/9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
-                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5.4",
-                "vimeo/psalm": "^4.7",
-                "webimpress/coding-standard": "^1.2.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2.x-dev",
-                    "dev-develop": "2.3.x-dev",
-                    "dev-release-1.0": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webimpress\\SafeWriter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Tool to write files safely, to avoid race conditions",
-            "keywords": [
-                "concurrent write",
-                "file writer",
-                "race condition",
-                "safe writer",
-                "webimpress"
-            ],
-            "support": {
-                "issues": "https://github.com/webimpress/safe-writer/issues",
-                "source": "https://github.com/webimpress/safe-writer/tree/2.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/michalbundyra",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-04-19T16:34:45+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5316,17 +5144,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "mikey179/vfsstream": 15
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/docs/book/lazy-services.md
+++ b/docs/book/lazy-services.md
@@ -27,11 +27,11 @@ object is really needed.
 `Laminas\ServiceManager\Proxy\LazyServiceFactory` is a [delegator factory](delegators.md)
 capable of generating lazy loading proxies for your services.
 
-The lazy service facilities depend on [ProxyManager](https://github.com/Ocramius/ProxyManager);
+The lazy service facilities depend on [ProxyManager](https://github.com/FriendsOfPHP/proxy-manager-lts);
 you will need to install that package before using the feature:
 
 ```php
-$ composer require ocramius/proxy-manager
+$ composer require friendsofphp/proxy-manager-lts
 ```
 
 ## Practical example

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,150 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.0.0@4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8">
+<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
   <file src="src/AbstractFactory/ConfigAbstractFactory.php">
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $requestedName(...$arguments)</code>
     </InvalidStringClass>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$serviceDependencies</code>
       <code>$serviceDependencies</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$config[self::class]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$config</code>
       <code>$dependencies</code>
     </MixedAssignment>
   </file>
   <file src="src/AbstractFactory/ReflectionBasedAbstractFactory.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$requestedName</code>
     </ArgumentTypeCoercion>
-    <LessSpecificReturnStatement occurrences="3">
+    <LessSpecificReturnStatement>
       <code>new $requestedName()</code>
       <code>new $requestedName()</code>
       <code>new $requestedName(...$parameters)</code>
     </LessSpecificReturnStatement>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$requestedName</code>
     </MissingParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$requestedName</code>
       <code>$requestedName</code>
       <code>$requestedName</code>
     </MixedArgument>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>new $requestedName()</code>
       <code>new $requestedName()</code>
       <code>new $requestedName(...$parameters)</code>
     </MixedMethodCall>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>DispatchableInterface</code>
     </MoreSpecificReturnType>
-    <RedundantCondition occurrences="1">
+    <PossiblyNullArgument>
+      <code>$type</code>
+    </PossiblyNullArgument>
+    <RedundantCondition>
       <code>is_string($type)</code>
     </RedundantCondition>
-    <UndefinedDocblockClass occurrences="1">
+    <UndefinedDocblockClass>
       <code>DispatchableInterface</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/AbstractPluginManager.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$config</code>
       <code>$config</code>
     </ArgumentTypeCoercion>
-    <ImplementedParamTypeMismatch occurrences="1">
+    <ImplementedParamTypeMismatch>
       <code>$service</code>
     </ImplementedParamTypeMismatch>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>setService</code>
     </MissingReturnType>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$service</code>
     </MixedArgumentTypeCoercion>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$name</code>
     </ParamNameMismatch>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_object($configInstanceOrParentLocator)</code>
     </RedundantConditionGivenDocblockType>
-    <UnusedPsalmSuppress occurrences="1">
+    <UnusedPsalmSuppress>
       <code>MixedAssignment</code>
     </UnusedPsalmSuppress>
   </file>
   <file src="src/Config.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>ArrayUtils::merge($a, $b)</code>
     </LessSpecificReturnStatement>
-    <MixedArrayTypeCoercion occurrences="1">
-      <code>$this-&gt;allowedKeys[$key]</code>
+    <MixedArrayTypeCoercion>
+      <code><![CDATA[$this->allowedKeys[$key]]]></code>
     </MixedArrayTypeCoercion>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>ServiceManagerConfigurationType</code>
     </MoreSpecificReturnType>
-    <UnusedPsalmSuppress occurrences="2">
+    <UnusedPsalmSuppress>
       <code>MixedReturnTypeCoercion</code>
       <code>MixedReturnTypeCoercion</code>
     </UnusedPsalmSuppress>
   </file>
   <file src="src/Exception/CyclicAliasException.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>self::deDuplicateDetectedCycles($detectedCycles)</code>
     </InvalidArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$alias</code>
       <code>$detectedCycles</code>
     </MixedArgumentTypeCoercion>
-    <PossiblyFalseOperand occurrences="1">
+    <PossiblyFalseOperand>
       <code>$cycle</code>
     </PossiblyFalseOperand>
   </file>
   <file src="src/Factory/InvokableFactory.php">
-    <InvalidStringClass occurrences="2">
+    <InvalidStringClass>
       <code>new $requestedName($options)</code>
       <code>new $requestedName()</code>
     </InvalidStringClass>
   </file>
   <file src="src/Proxy/LazyServiceFactory.php">
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType>
       <code>$wrappedInstance</code>
     </MissingClosureParamType>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$wrappedInstance</code>
     </MixedAssignment>
   </file>
   <file src="src/ServiceManager.php">
-    <InvalidArgument occurrences="3">
-      <code>['delegators' =&gt; [$name =&gt; [$factory]]]</code>
-      <code>['initializers' =&gt; [$initializer]]</code>
-      <code>['lazy_services' =&gt; ['class_map' =&gt; [$name =&gt; $class ?: $name]]]</code>
+    <InvalidArgument>
+      <code><![CDATA[['delegators' => [$name => [$factory]]]]]></code>
+      <code><![CDATA[['initializers' => [$initializer]]]]></code>
+      <code><![CDATA[['lazy_services' => ['class_map' => [$name => $class ?: $name]]]]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="6">
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
+    <InvalidArrayOffset>
+      <code><![CDATA[$this->services[$service]]]></code>
     </InvalidArrayOffset>
-    <InvalidCast occurrences="6">
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
+    <InvalidCast>
       <code>$service</code>
     </InvalidCast>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;factories</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->factories]]></code>
     </InvalidPropertyAssignmentValue>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>function () use ($name, $options) {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType>
       <code>addAbstractFactory</code>
       <code>addDelegator</code>
       <code>addInitializer</code>
@@ -155,146 +148,142 @@
       <code>setService</code>
       <code>setShared</code>
     </MissingReturnType>
-    <MixedArgument occurrences="11">
+    <MixedArgument>
       <code>$abstractFactory</code>
-      <code>$config['aliases']</code>
-      <code>$config['delegators']</code>
-      <code>$config['delegators']</code>
-      <code>$config['factories']</code>
-      <code>$config['initializers']</code>
-      <code>$config['invokables']</code>
-      <code>$config['invokables']</code>
-      <code>$config['lazy_services']</code>
-      <code>$config['lazy_services']['class_map']</code>
-      <code>$config['shared']</code>
+      <code><![CDATA[$config['aliases']]]></code>
+      <code><![CDATA[$config['delegators']]]></code>
+      <code><![CDATA[$config['delegators']]]></code>
+      <code><![CDATA[$config['factories']]]></code>
+      <code><![CDATA[$config['initializers']]]></code>
+      <code><![CDATA[$config['invokables']]]></code>
+      <code><![CDATA[$config['invokables']]]></code>
+      <code><![CDATA[$config['lazy_services']]]></code>
+      <code><![CDATA[$config['lazy_services']['class_map']]]></code>
+      <code><![CDATA[$config['shared']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="8">
+    <MixedArgumentTypeCoercion>
       <code>$alias</code>
       <code>$alias</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
-      <code>$service</code>
       <code>$service</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayTypeCoercion occurrences="6">
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
-      <code>$this-&gt;services[$service]</code>
+    <MixedArrayTypeCoercion>
+      <code><![CDATA[$this->services[$service]]]></code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$abstractFactories</code>
       <code>$abstractFactory</code>
       <code>$abstractFactory</code>
-      <code>$config['aliases']</code>
+      <code><![CDATA[$config['aliases']]]></code>
       <code>$key</code>
-      <code>$this-&gt;aliases</code>
-      <code>$this-&gt;factories</code>
-      <code>$this-&gt;shared</code>
-      <code>$this-&gt;sharedByDefault</code>
+      <code><![CDATA[$this->aliases]]></code>
+      <code><![CDATA[$this->factories]]></code>
+      <code><![CDATA[$this->shared]]></code>
+      <code><![CDATA[$this->sharedByDefault]]></code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
-      <code>$config['aliases']</code>
-      <code>$config['aliases'] ?? []</code>
-      <code>$config['factories']</code>
-      <code>$config['shared']</code>
+    <MixedOperand>
+      <code><![CDATA[$config['aliases']]]></code>
+      <code><![CDATA[$config['aliases'] ?? []]]></code>
+      <code><![CDATA[$config['factories']]]></code>
+      <code><![CDATA[$config['shared']]]></code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="2">
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->delegators]]></code>
+      <code><![CDATA[$this->factories]]></code>
+      <code><![CDATA[$this->initializers]]></code>
+    </MixedPropertyTypeCoercion>
+    <MixedReturnTypeCoercion>
+      <code>$factory</code>
+      <code><![CDATA[(callable(ContainerInterface,string,array<mixed>|null):object)|Factory\FactoryInterface]]></code>
+    </MixedReturnTypeCoercion>
+    <ParamNameMismatch>
       <code>$name</code>
       <code>$name</code>
     </ParamNameMismatch>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType>
       <code>$sharedAlias</code>
       <code>$sharedAlias</code>
     </TypeDoesNotContainType>
-    <UnusedForeachValue occurrences="3">
+    <UnusedForeachValue>
       <code>$delegatorFactory</code>
       <code>$service</code>
       <code>$target</code>
     </UnusedForeachValue>
-    <UnusedVariable occurrences="1">
+    <UnusedVariable>
       <code>$key</code>
     </UnusedVariable>
   </file>
   <file src="src/Test/CommonPluginManagerTrait.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion>
       <code>$expected</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
+      <code><![CDATA[$this->getServiceNotFoundException()]]></code>
+      <code><![CDATA[$this->getServiceNotFoundException()]]></code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testInstanceOfMatches</code>
       <code>testLoadingInvalidElementRaisesException</code>
       <code>testPluginAliasesResolve</code>
       <code>testRegisteringInvalidElementRaisesException</code>
       <code>testShareByDefaultAndSharedByDefault</code>
     </MissingReturnType>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$alias</code>
       <code>$expected</code>
       <code>$shareByDefault</code>
       <code>$sharedByDefault</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="src/Tool/ConfigDumper.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($className)</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>validateClassName</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$config['service_manager']</code>
-      <code>$config['service_manager']['factories']</code>
+    <MixedArgument>
+      <code><![CDATA[$config['service_manager']]]></code>
+      <code><![CDATA[$config['service_manager']['factories']]]></code>
       <code>$key</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$className</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="4">
-      <code>$config['service_manager']['factories']</code>
-      <code>$config['service_manager']['factories'][$className]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$config['service_manager']['factories']]]></code>
+      <code><![CDATA[$config['service_manager']['factories'][$className]]]></code>
       <code>$config[ConfigAbstractFactory::class][$className]</code>
       <code>$config[ConfigAbstractFactory::class][$className]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$dependency</code>
       <code>$key</code>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$key</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>getParameters</code>
-    </PossiblyNullReference>
-    <UnusedForeachValue occurrences="1">
+    <UnusedForeachValue>
       <code>$dependency</code>
     </UnusedForeachValue>
   </file>
   <file src="src/Tool/ConfigDumperCommand.php">
-    <MixedArgument occurrences="14">
-      <code>$arguments-&gt;class</code>
-      <code>$arguments-&gt;class</code>
-      <code>$arguments-&gt;config</code>
-      <code>$arguments-&gt;configFile</code>
-      <code>$arguments-&gt;configFile</code>
-      <code>$arguments-&gt;ignoreUnresolved</code>
-      <code>$arguments-&gt;message</code>
+    <MixedArgument>
+      <code><![CDATA[$arguments->class]]></code>
+      <code><![CDATA[$arguments->class]]></code>
+      <code><![CDATA[$arguments->config]]></code>
+      <code><![CDATA[$arguments->configFile]]></code>
+      <code><![CDATA[$arguments->configFile]]></code>
+      <code><![CDATA[$arguments->ignoreUnresolved]]></code>
+      <code><![CDATA[$arguments->message]]></code>
       <code>$class</code>
       <code>$class</code>
       <code>$configFile</code>
@@ -303,42 +292,39 @@
       <code>$configFile</code>
       <code>$configFile</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$arg1</code>
       <code>$arg1</code>
       <code>$configFile</code>
     </MixedAssignment>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>false</code>
     </RedundantCondition>
   </file>
   <file src="src/Tool/FactoryCreator.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strrpos($className, '\\')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($className, '\\')]]></code>
     </PossiblyFalseOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>getParameters</code>
-    </PossiblyNullReference>
   </file>
   <file src="src/Tool/FactoryCreatorCommand.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$class</code>
       <code>$class</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$arg1</code>
     </MixedAssignment>
   </file>
   <file src="test/AbstractFactory/ConfigAbstractFactoryTest.php">
-    <InvalidArgument occurrences="1">
-      <code>'Holistic'</code>
+    <InvalidArgument>
+      <code><![CDATA['Holistic']]></code>
     </InvalidArgument>
   </file>
   <file src="test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php">
-    <DocblockTypeContradiction occurrences="8">
+    <DocblockTypeContradiction>
       <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
@@ -348,41 +334,70 @@
       <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
     </DocblockTypeContradiction>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/AbstractPluginManagerTest.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>setServiceLocator</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="5"/>
-    <MissingClosureParamType occurrences="4">
+    <InvalidArgument>
+      <code><![CDATA[[
+            'factories'  => [
+                stdClass::class => InvokableFactory::class,
+            ],
+            'delegators' => [
+                stdClass::class => [
+                    TestAsset\PreDelegator::class,
+                    static function ($container, $name, $callback) {
+                        $instance      = $callback();
+                        $instance->foo = 'bar';
+
+                        return $instance;
+                    },
+                ],
+            ],
+        ]]]></code>
+      <code>static function ($errno, $errstr): void {
+            self::assertEquals(E_USER_DEPRECATED, $errno);
+        }</code>
+      <code>static function ($errno, $errstr): void {
+            self::assertEquals(E_USER_DEPRECATED, $errno);
+        }</code>
+      <code>static function ($errno, $errstr): void {
+            self::assertEquals(E_USER_DEPRECATED, $errno);
+        }</code>
+      <code>static function ($errno, $errstr): void {
+            self::assertEquals(E_USER_DEPRECATED, $errno);
+        }</code>
+    </InvalidArgument>
+    <MissingClosureParamType>
       <code>$callback</code>
       <code>$container</code>
       <code>$name</code>
       <code>$plugin</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>static function ($container, $name, $callback) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$arg</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$instance</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$callback()</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedPropertyAssignment occurrences="1">
+    <MixedPropertyAssignment>
       <code>$instance</code>
     </MixedPropertyAssignment>
-    <UnusedClosureParam occurrences="6">
+    <UnusedClosureParam>
       <code>$container</code>
       <code>$errstr</code>
       <code>$errstr</code>
@@ -392,17 +407,36 @@
     </UnusedClosureParam>
   </file>
   <file src="test/CommonServiceLocatorBehaviorsTrait.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>getServiceLocator</code>
     </DeprecatedMethod>
-    <EmptyArrayAccess occurrences="1">
-      <code>$object['get'][0]</code>
+    <EmptyArrayAccess>
+      <code><![CDATA[$object['get'][0]]]></code>
     </EmptyArrayAccess>
-    <InvalidArgument occurrences="2"/>
-    <InvalidArrayOffset occurrences="1">
-      <code>$config['shared']</code>
+    <InvalidArgument>
+      <code><![CDATA[[
+            'factories' => [
+                stdClass::class => static function (ServiceLocatorInterface $serviceLocator, $className): stdClass {
+                    self::assertEquals(stdClass::class, $className);
+
+                    return new stdClass();
+                },
+            ],
+        ]]]></code>
+      <code><![CDATA[[
+            'factories' => [
+                stdClass::class => static function (ServiceLocatorInterface $serviceLocator, $className): stdClass {
+                    self::assertEquals(stdClass::class, $className);
+
+                    return new stdClass();
+                },
+            ],
+        ]]]></code>
+    </InvalidArgument>
+    <InvalidArrayOffset>
+      <code><![CDATA[$config['shared']]]></code>
     </InvalidArrayOffset>
-    <MissingClosureParamType occurrences="8">
+    <MissingClosureParamType>
       <code>$callback</code>
       <code>$className</code>
       <code>$container</code>
@@ -412,21 +446,21 @@
       <code>$name</code>
       <code>$requestedName</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>static function ($container, $name, $callback) {</code>
     </MissingClosureReturnType>
-    <MissingConstructor occurrences="2">
+    <MissingConstructor>
       <code>$creationContext</code>
       <code>$creationContext</code>
     </MissingConstructor>
-    <MixedArrayAssignment occurrences="1">
-      <code>$object[$shared ? $method : 'build'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$object[$shared ? $method : 'build'][]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset>
       <code>$names[$name]</code>
-      <code>$object[$shared ? $method : 'build']</code>
+      <code><![CDATA[$object[$shared ? $method : 'build']]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="22">
+    <MixedAssignment>
       <code>$first</code>
       <code>$idx1</code>
       <code>$idx2</code>
@@ -445,29 +479,29 @@
       <code>$object2</code>
       <code>$object2</code>
       <code>$object2</code>
-      <code>$object[$shared ? $method : 'build'][]</code>
+      <code><![CDATA[$object[$shared ? $method : 'build'][]]]></code>
       <code>$second</code>
       <code>$shared</code>
       <code>$shared</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$callback()</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedPropertyAssignment occurrences="1">
+    <MixedPropertyAssignment>
       <code>$instance</code>
     </MixedPropertyAssignment>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$object</code>
     </PossiblyUndefinedVariable>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>has</code>
     </TooManyArguments>
-    <UnusedClosureParam occurrences="9">
+    <UnusedClosureParam>
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
@@ -480,52 +514,65 @@
     </UnusedClosureParam>
   </file>
   <file src="test/ConfigTest.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$configInstance</code>
       <code>$configuration</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>toArray</code>
     </MixedMethodCall>
   </file>
+  <file src="test/Exception/CyclicAliasExceptionTest.php">
+    <InvalidDocblock>
+      <code>public function aliasesProvider(): array</code>
+      <code>public function cyclicAliasProvider(): array</code>
+    </InvalidDocblock>
+    <MixedInferredReturnType>
+      <code><![CDATA[array<
+     *     non-empty-string,
+     *     array{0:non-empty-string,1:array<non-empty-string,non-empty-string>,non-empty-string}
+     * >]]></code>
+      <code><![CDATA[array<string, array{0: array<string, string>, string}>]]></code>
+    </MixedInferredReturnType>
+  </file>
   <file src="test/LazyServiceIntegrationTest.php">
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>array_filter(spl_autoload_functions(), $filter)</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>AutoloaderInterface[]</code>
     </InvalidReturnType>
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType>
       <code>$autoload</code>
     </MissingClosureParamType>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition>
       <code>assertIsArray</code>
       <code>assertIsArray</code>
     </RedundantCondition>
   </file>
   <file src="test/Proxy/LazyServiceFactoryTest.php">
-    <InvalidArgument occurrences="2">
-      <code>[$callback, 'callback']</code>
-      <code>[$callback, 'callback']</code>
+    <InvalidArgument>
+      <code><![CDATA[[$callback, 'callback']]]></code>
+      <code><![CDATA[[$callback, 'callback']]]></code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$className</code>
       <code>$initializer</code>
     </MissingClosureParamType>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$initializer($wrappedInstance, $proxy)</code>
     </MixedFunctionCall>
-    <UnusedVariable occurrences="1">
+    <UnusedVariable>
       <code>$wrappedInstance</code>
     </UnusedVariable>
   </file>
   <file src="test/ServiceManagerTest.php">
-    <MissingClosureParamType occurrences="3">
+    <MissingClosureParamType>
       <code>$context</code>
       <code>$context</code>
       <code>$name</code>
     </MissingClosureParamType>
-    <MixedAssignment occurrences="17">
+    <MixedAssignment>
       <code>$a</code>
       <code>$alias</code>
       <code>$alias</code>
@@ -544,17 +591,17 @@
       <code>$serviceFromAlias</code>
       <code>$serviceFromServiceNameAfterUsingAlias</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$inc</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="2">
-      <code>$instance-&gt;foo</code>
-      <code>$instance-&gt;option</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$instance->foo]]></code>
+      <code><![CDATA[$instance->option]]></code>
     </MixedPropertyFetch>
-    <UnusedClosureParam occurrences="6">
+    <UnusedClosureParam>
       <code>$container</code>
       <code>$container</code>
       <code>$context</code>
@@ -564,40 +611,40 @@
     </UnusedClosureParam>
   </file>
   <file src="test/Tool/ConfigDumperCommandTest.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$factoryConfig[ObjectWithObjectScalarDependency::class]</code>
       <code>$factoryConfig[ObjectWithObjectScalarDependency::class]</code>
       <code>$factoryConfig[SimpleDependencyObject::class]</code>
       <code>$factoryConfig[SimpleDependencyObject::class]</code>
       <code>$factoryConfig[SimpleDependencyObject::class]</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <UnresolvableInclude occurrences="3">
+    <UnresolvableInclude>
       <code>include $config</code>
       <code>include $config</code>
       <code>include $config</code>
     </UnresolvableInclude>
   </file>
   <file src="test/Tool/ConfigDumperTest.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$test</code>
     </MixedAssignment>
-    <UnresolvableInclude occurrences="1">
+    <UnresolvableInclude>
       <code>include $file</code>
     </UnresolvableInclude>
   </file>
   <file src="test/Tool/FactoryCreatorCommandTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>ConfigDumperCommand::class</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ConfigDumperCommand</code>
     </UndefinedClass>
   </file>

--- a/src/Proxy/LazyServiceFactory.php
+++ b/src/Proxy/LazyServiceFactory.php
@@ -14,7 +14,7 @@ use Psr\Container\ContainerInterface;
 use function sprintf;
 
 /**
- * Delegator factory responsible of instantiating lazy loading value holder proxies of
+ * Delegator factory responsible for instantiating lazy loading value holder proxies of
  * given services at runtime
  *
  * @link https://github.com/Ocramius/ProxyManager/blob/master/docs/lazy-loading-value-holder.md

--- a/src/Test/CommonPluginManagerTrait.php
+++ b/src/Test/CommonPluginManagerTrait.php
@@ -24,7 +24,6 @@ trait CommonPluginManagerTrait
     {
         $manager    = $this->getPluginManager();
         $reflection = new ReflectionProperty($manager, 'instanceOf');
-        $reflection->setAccessible(true);
         $this->assertEquals($this->getInstanceOf(), $reflection->getValue($manager), 'instanceOf does not match');
     }
 
@@ -36,11 +35,9 @@ trait CommonPluginManagerTrait
 
         foreach ($reflection->getProperties() as $prop) {
             if ($prop->getName() === 'shareByDefault') {
-                $prop->setAccessible(true);
                 $shareByDefault = $prop->getValue($manager);
             }
             if ($prop->getName() === 'sharedByDefault') {
-                $prop->setAccessible(true);
                 $sharedByDefault = $prop->getValue($manager);
             }
         }
@@ -83,8 +80,7 @@ trait CommonPluginManagerTrait
     {
         $manager    = $this->getPluginManager();
         $reflection = new ReflectionProperty($manager, 'aliases');
-        $reflection->setAccessible(true);
-        $data = [];
+        $data       = [];
         foreach ($reflection->getValue($manager) as $alias => $expected) {
             $data[] = [$alias, $expected];
         }

--- a/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
+++ b/test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php
@@ -87,10 +87,10 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive(
-                ['config'],
-                [TestAsset\SampleInterface::class],
-            )
+            ->willReturnMap([
+                ['config', false],
+                [TestAsset\SampleInterface::class, false],
+            ])
             ->willReturn(false, false);
 
         $this->expectException(ServiceNotFoundException::class);
@@ -141,11 +141,10 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive(
-                ['config'],
-                [TestAsset\SampleInterface::class],
-            )
-            ->willReturn(false, true);
+            ->willReturnMap([
+                ['config', false],
+                [TestAsset\SampleInterface::class, true],
+            ]);
 
         $sample = $this->createMock(TestAsset\SampleInterface::class);
 
@@ -169,11 +168,10 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive(
-                ['config'],
-                ['ValidatorManager'],
-            )
-            ->willReturn(false, true);
+            ->willReturnMap([
+                ['config', false],
+                ['ValidatorManager', true],
+            ]);
 
         $validators = $this->createMock(TestAsset\ValidatorPluginManager::class);
 
@@ -201,12 +199,11 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(3))
             ->method('has')
-            ->withConsecutive(
-                ['config'],
-                [TestAsset\SampleInterface::class],
-                ['ValidatorManager'],
-            )
-            ->willReturn(true, true, true);
+            ->willReturnMap([
+                ['config', true],
+                [TestAsset\SampleInterface::class, true],
+                ['ValidatorManager', true],
+            ]);
 
         $config     = ['foo' => 'bar'];
         $sample     = $this->createMock(TestAsset\SampleInterface::class);
@@ -215,12 +212,11 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(3))
             ->method('get')
-            ->withConsecutive(
-                ['config'],
-                [TestAsset\SampleInterface::class],
-                ['ValidatorManager'],
-            )
-            ->willReturn($config, $sample, $validators);
+            ->willReturnMap([
+                ['config', $config],
+                [TestAsset\SampleInterface::class, $sample],
+                ['ValidatorManager', $validators],
+            ]);
 
         $factory  = new ReflectionBasedAbstractFactory([TestAsset\ValidatorPluginManager::class => 'ValidatorManager']);
         $instance = $factory->__invoke($this->container, TestAsset\ClassWithMixedConstructorParameters::class);
@@ -257,11 +253,10 @@ final class ReflectionBasedAbstractFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive(
-                ['config'],
-                [ArrayAccess::class],
-            )
-            ->willReturn(false, false);
+            ->willReturnMap([
+                ['config', false],
+                [ArrayAccess::class, false],
+            ]);
 
         $instance = $this->factory->__invoke(
             $this->container,

--- a/test/CommonServiceLocatorBehaviorsTrait.php
+++ b/test/CommonServiceLocatorBehaviorsTrait.php
@@ -742,8 +742,7 @@ trait CommonServiceLocatorBehaviorsTrait
     {
         $container = $this->createContainer();
         $container->mapLazyService('foo', self::class);
-        $r = new ReflectionProperty($container, 'lazyServices');
-        $r->setAccessible(true);
+        $r            = new ReflectionProperty($container, 'lazyServices');
         $lazyServices = $r->getValue($container);
 
         self::assertIsArray($lazyServices);

--- a/test/LazyServiceIntegrationTest.php
+++ b/test/LazyServiceIntegrationTest.php
@@ -38,11 +38,8 @@ use function unlink;
  */
 final class LazyServiceIntegrationTest extends TestCase
 {
-    /**
-     * @var string
-     * @psalm-var non-empty-string
-     */
-    public $proxyDir;
+    /** @var non-empty-string */
+    private string $proxyDir;
 
     protected function setUp(): void
     {
@@ -70,7 +67,7 @@ final class LazyServiceIntegrationTest extends TestCase
         }
     }
 
-    public function removeDir(string $directory): void
+    private function removeDir(string $directory): void
     {
         $handle = opendir($directory);
         while (false !== ($item = readdir($handle))) {
@@ -95,7 +92,7 @@ final class LazyServiceIntegrationTest extends TestCase
         rmdir($directory);
     }
 
-    public function listProxyFiles(): RegexIterator
+    private function listProxyFiles(): RegexIterator
     {
         $rdi = new RecursiveDirectoryIterator($this->proxyDir);
         $rii = new RecursiveIteratorIterator($rdi);
@@ -103,7 +100,7 @@ final class LazyServiceIntegrationTest extends TestCase
         return new RegexIterator($rii, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH);
     }
 
-    public function assertProxyDirEmpty(string $message = ''): void
+    private function assertProxyDirEmpty(string $message = ''): void
     {
         $message = $message ?: 'Expected empty proxy directory; found files';
 
@@ -111,7 +108,7 @@ final class LazyServiceIntegrationTest extends TestCase
         self::assertEquals([], iterator_to_array($this->listProxyFiles()), $message);
     }
 
-    public function assertProxyFileWritten(string $message = ''): void
+    private function assertProxyFileWritten(string $message = ''): void
     {
         $message = $message ?: 'Expected ProxyManager to write at least one class file; none found';
 
@@ -312,7 +309,7 @@ final class LazyServiceIntegrationTest extends TestCase
     /**
      * @return AutoloaderInterface[]
      */
-    protected function getRegisteredProxyAutoloadFunctions(): array
+    private function getRegisteredProxyAutoloadFunctions(): array
     {
         $filter = static fn($autoload): bool => $autoload instanceof AutoloaderInterface;
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -374,10 +374,6 @@ final class ServiceManagerTest extends TestCase
         $abstractFactory
             ->expects(self::once())
             ->method('canCreate')
-            ->withConsecutive(
-                [self::anything(), self::equalTo('Alias')],
-                [self::anything(), self::equalTo('ServiceName')]
-            )
             ->willReturnCallback(static fn ($context, string $name): bool => $name === 'Alias');
 
         self::assertTrue($serviceManager->has('Alias'));
@@ -416,10 +412,6 @@ final class ServiceManagerTest extends TestCase
         $abstractFactory
             ->expects(self::exactly(2))
             ->method('canCreate')
-            ->withConsecutive(
-                [self::anything(), 'Alias'],
-                [self::anything(), 'ServiceName']
-            )
             ->willReturnCallback(static fn ($context, string $name): bool => $name === 'ServiceName');
 
         self::assertTrue($serviceManager->has('Alias'));
@@ -441,11 +433,10 @@ final class ServiceManagerTest extends TestCase
         $abstractFactory
             ->expects(self::exactly(2))
             ->method('canCreate')
-            ->withConsecutive(
-                [self::anything(), 'Alias'],
-                [self::anything(), 'ServiceName']
-            )
-            ->willReturn(false);
+            ->willReturnMap([
+                [self::anything(), 'Alias', false],
+                [self::anything(), 'ServiceName', false],
+            ]);
 
         self::assertFalse($serviceManager->has('Alias'));
     }

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,7 +1,5 @@
 <?php // phpcs:disable Generic.Files.LineLength.TooLong,SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
 
-if (PHP_VERSION_ID >= 80100) {
-    require __DIR__ . '/TestAsset/laminas-code/ParameterReflection.php';
-    require __DIR__ . '/TestAsset/laminas-code/MethodReflection.php';
-    require __DIR__ . '/TestAsset/laminas-code/ClassReflection.php';
-}
+require __DIR__ . '/TestAsset/laminas-code/ParameterReflection.php';
+require __DIR__ . '/TestAsset/laminas-code/MethodReflection.php';
+require __DIR__ . '/TestAsset/laminas-code/ClassReflection.php';


### PR DESCRIPTION
My hot take on this one.

Unfortunately, https://github.com/Ocramius/ProxyManager hasn't received any attention for PHP after 8.0, and this is blocking `laminas-servicemanager` from being properly upgraded.

This PR is required for https://github.com/laminas/laminas-servicemanager/pull/173, which in turn is required for https://github.com/laminas/laminas-mail/pull/233 any many similar others.

No https://github.com/laminas/laminas-servicemanager/labels/BC%20Break here:

* people who rely on `ocramius/proxy-manager` are still stuck on PHP 8.0 and are going to be stuck on `laminas/laminas-servicemanager:v3.20` forever.
* people who upgraded to PHP >= 8.1 already had to drop `ocramius/proxy-manager` usage because it never added support for newer PHP versions