### PR TITLE
Introduce `ConfigValidatorInterface` for minimum runtime validation of SM configurations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "laminas/laminas-dependency-plugin": "^2.2",
         "mikey179/vfsstream": "^1.6.11",
         "phpbench/phpbench": "^1.2.9",
-        "phpunit/phpunit": "^10.0.17",
+        "phpunit/phpunit": "^10.1",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcc74076fd03d8f52e6d9320feeaf24e",
+    "content-hash": "744296c1951e44221fda0b58df6deaf8",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -2051,16 +2051,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.0",
+            "version": "10.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "fc4f5ee614fa82d50ecf9014b51af0a9561f3df8"
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fc4f5ee614fa82d50ecf9014b51af0a9561f3df8",
-                "reference": "fc4f5ee614fa82d50ecf9014b51af0a9561f3df8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/884a0da7f9f46f28b2cb69134217fd810b793974",
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974",
                 "shasum": ""
             },
             "require": {
@@ -2079,7 +2079,7 @@
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2117,7 +2117,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.1"
             },
             "funding": [
                 {
@@ -2125,20 +2125,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-13T07:08:27+00:00"
+            "time": "2023-04-17T12:15:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
+                "reference": "5647d65443818959172645e7ed999217360654b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
+                "reference": "5647d65443818959172645e7ed999217360654b6",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
             },
             "funding": [
                 {
@@ -2185,7 +2186,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-10T16:53:14+00:00"
+            "time": "2023-05-07T09:13:23+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2370,16 +2371,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.19",
+            "version": "10.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62"
+                "reference": "6f0cd95be71add539f8fd2be25b2a4a29789000b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/20c23e85c86e5c06d63538ba464e8054f4744e62",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6f0cd95be71add539f8fd2be25b2a4a29789000b",
+                "reference": "6f0cd95be71add539f8fd2be25b2a4a29789000b",
                 "shasum": ""
             },
             "require": {
@@ -2393,7 +2394,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-code-coverage": "^10.1.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-invoker": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -2419,7 +2420,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2451,7 +2452,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.2"
             },
             "funding": [
                 {
@@ -2467,7 +2468,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:46:33+00:00"
+            "time": "2023-04-22T07:38:19+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2930,16 +2931,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/aae9a0a43bff37bd5d8d0311426c87bf36153f02",
-                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
@@ -2985,7 +2986,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -2993,7 +2994,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-23T05:12:41+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,11 +3,11 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          cacheDirectory=".phpunit.cache">
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">./src</directory>
     </include>
-  </coverage>
+  </source>
   <testsuites>
     <testsuite name="laminas-servicemanager Test Suite">
       <directory>./test/</directory>

--- a/src/ConfigValidator.php
+++ b/src/ConfigValidator.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\ServiceManager;
+
+use Laminas\ServiceManager\Exception\InvalidArgumentException;
+use Laminas\ServiceManager\Exception\InvalidServiceManagerConfigurationException;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Initializer\InitializerInterface;
+
+use function array_keys;
+use function class_exists;
+use function class_implements;
+use function get_debug_type;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_callable;
+use function is_string;
+use function method_exists;
+use function sprintf;
+
+final class ConfigValidator implements ConfigValidatorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function assertIsValidConfiguration(array $config): void
+    {
+        if (isset($config['abstract_factories'])) {
+            $this->assertIsValidAbstractFactoriesConfiguration($config['abstract_factories']);
+        }
+
+        if (isset($config['aliases'])) {
+            $this->assertIsValidAliasesConfiguration($config['aliases']);
+        }
+
+        if (isset($config['delegators'])) {
+            $this->assertIsValidDelegatorConfiguration($config['delegators']);
+        }
+
+        if (isset($config['factories'])) {
+            $this->assertIsValidFactoryConfiguration($config['factories']);
+        }
+
+        if (isset($config['initializers'])) {
+            $this->assertIsValidInitializerConfiguration($config['initializers']);
+        }
+
+        if (isset($config['invokables'])) {
+            $this->assertIsValidInvokableConfiguration($config['invokables']);
+        }
+
+        if (isset($config['lazy_services'])) {
+            $this->assertIsValidLazyServiceConfiguration($config['lazy_services']);
+        }
+
+        if (isset($config['services'])) {
+            $this->assertIsValidServiceConfiguration($config['services']);
+        }
+
+        if (isset($config['shared'])) {
+            $this->assertIsValidShareConfiguration($config['shared']);
+        }
+
+        if (isset($config['shared_by_default']) && ! is_bool($config['shared_by_default'])) {
+            throw new InvalidServiceManagerConfigurationException(
+                'Configuration `shared_by_default` has to represent an array map where the service name'
+                . ' is mapped with a boolean.'
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isValidConfiguration(array $config): bool
+    {
+        try {
+            self::assertIsValidConfiguration($config);
+        } catch (InvalidArgumentException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function assertIsValidShareConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonArrayConfiguration('shared', $configuration);
+        }
+
+        foreach ($configuration as $service => $share) {
+            if (! is_string($service)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('shared');
+            }
+
+            if (! is_bool($share)) {
+                throw new InvalidServiceManagerConfigurationException(
+                    'Configuration `share` has to represent an array map where the service name'
+                    . ' is mapped with a boolean.'
+                );
+            }
+        }
+    }
+
+    private function assertIsValidServiceConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonArrayConfiguration('services', $configuration);
+        }
+
+        foreach (array_keys($configuration) as $serviceName) {
+            if (! is_string($serviceName)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('services');
+            }
+        }
+    }
+
+    private function assertIsValidLazyServiceConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('lazy_services');
+        }
+
+        if (isset($configuration['class_map'])) {
+            if (! is_array($configuration['class_map'])) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('lazy_services.class_map');
+            }
+
+            /** @var mixed $instanceTarget */
+            foreach ($configuration['class_map'] as $serviceName => $instanceTarget) {
+                if (! is_string($serviceName)) {
+                    throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration(
+                        'lazy_services.class_map'
+                    );
+                }
+
+                if (! is_string($instanceTarget)) {
+                    throw new InvalidServiceManagerConfigurationException(sprintf(
+                        'Configuration `lazy_services.class_map` value is expected to contain a map of service'
+                        . ' names targeting implementations. Expected `class-string`; "%s" given',
+                        get_debug_type($instanceTarget)
+                    ));
+                } elseif (! class_exists($instanceTarget)) {
+                    throw new InvalidServiceManagerConfigurationException(sprintf(
+                        'Configuration `lazy_services.class_map` value is expected to contain a map of service'
+                        . ' names targeting implementations. Expected `class-string` to an existing class; "%s" given',
+                        get_debug_type($instanceTarget)
+                    ));
+                }
+            }
+        }
+
+        if (isset($configuration['proxies_namespace'])) {
+            if (! is_string($configuration['proxies_namespace']) || $configuration['proxies_namespace'] === '') {
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Configuration `lazy_services.proxies_namespace` is expected to contain a `non-empty-string`'
+                    . ' representing a namespace to be used when generating proxies; "%s" given',
+                    get_debug_type($configuration['proxies_namespace'])
+                ));
+            }
+        }
+
+        if (isset($configuration['proxies_target_dir'])) {
+            if (! is_string($configuration['proxies_target_dir']) || $configuration['proxies_target_dir'] === '') {
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Configuration `lazy_services.proxies_target_dir` is expected to contain a `non-empty-string`'
+                    . ' representing a directory to be used to store files when generating proxies; "%s" given',
+                    get_debug_type($configuration['proxies_target_dir'])
+                ));
+            }
+        }
+
+        if (isset($configuration['write_proxy_files']) && ! is_bool($configuration['write_proxy_files'])) {
+            throw new InvalidServiceManagerConfigurationException(
+                'Configuration `lazy_services.write_proxy_files` has to represent an array map where'
+                . ' the service name is mapped with a boolean.'
+            );
+        }
+    }
+
+    private function assertIsValidInvokableConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('invokables');
+        }
+
+        /**
+         * @var mixed $instanceTarget
+         * @var mixed $serviceName
+         */
+        foreach ($configuration as $serviceName => $instanceTarget) {
+            if (! is_string($serviceName)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('invokables');
+            }
+
+            if (! is_string($instanceTarget)) {
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Configuration `invokables` value is expected to contain a map of service'
+                    . ' names targeting implementations. Expected `class-string`; "%s" given',
+                    get_debug_type($instanceTarget)
+                ));
+            } elseif (! class_exists($instanceTarget)) {
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Configuration `invokables` value is expected to contain a map of service'
+                    . ' names targeting implementations. Expected `class-string` to an existing class; "%s" given',
+                    get_debug_type($instanceTarget)
+                ));
+            }
+        }
+    }
+
+    private function assertIsValidInitializerConfiguration(mixed $initializers): void
+    {
+        if (! is_array($initializers)) {
+            throw InvalidServiceManagerConfigurationException::fromNonArrayConfiguration(
+                'initializers',
+                $initializers
+            );
+        }
+
+        /** @var mixed $initializer */
+        foreach ($initializers as $initializer) {
+            if ($initializer instanceof InitializerInterface) {
+                continue;
+            }
+
+            if (
+                is_string($initializer)
+                && class_exists($initializer)
+                && method_exists($initializer, '__invoke')
+            ) {
+                // assume class-string providing a class which implements `__invoke` also implements expected signatures
+                continue;
+            }
+
+            if (is_callable($initializer)) {
+                // assume the callable implements expected signatures
+                continue;
+            }
+
+            throw new InvalidServiceManagerConfigurationException(sprintf(
+                'Provided `initializers` configuration has to represent an array of any of:'
+                . ' `%1$s` implementations'
+                . ', `class-string<%1$s>`'
+                . ', `class-string<object&%2$s>`'
+                . ', `%2$s`'
+                . '; "%3$s" given',
+                InitializerInterface::class,
+                'callable(ContainerInterface,mixed):void',
+                get_debug_type($initializer),
+            ));
+        }
+    }
+
+    private function assertIsValidAliasesConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('aliases');
+        }
+
+        /**
+         * @var mixed $alias
+         * @var mixed $target
+         */
+        foreach ($configuration as $alias => $target) {
+            if (! is_string($alias)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('aliases');
+            }
+
+            if (! is_string($target)) {
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Configuration `aliases` must be a map of alias names to target names and thus,'
+                    . ' represent strings; "%s" given',
+                    get_debug_type($target)
+                ));
+            }
+        }
+    }
+
+    private function assertIsValidDelegatorConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('delegators');
+        }
+
+        /**
+         * @var mixed $delegators
+         * @var mixed $delegatedServiceName
+         */
+        foreach ($configuration as $delegatedServiceName => $delegators) {
+            if (! is_string($delegatedServiceName)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('delegators');
+            }
+
+            if (! is_array($delegators)) {
+                throw InvalidServiceManagerConfigurationException::fromNonArrayConfiguration(
+                    sprintf('delegators.%s', $delegatedServiceName),
+                    $delegators
+                );
+            }
+
+            /**
+             * @var mixed $delegator
+             */
+            foreach ($delegators as $delegator) {
+                if ($delegator instanceof DelegatorFactoryInterface) {
+                    continue;
+                }
+
+                if (
+                    is_string($delegator)
+                    && class_exists($delegator)
+                    && method_exists($delegator, '__invoke')
+                ) {
+                    // assume class-string providing a class which implements `__invoke`
+                    // also implements expected signatures
+                    continue;
+                }
+
+                if (is_callable($delegator)) {
+                    // assume the callable implements expected signatures
+                    continue;
+                }
+
+                throw new InvalidServiceManagerConfigurationException(sprintf(
+                    'Provided `delegators.%1$s` configuration has to represent an array of any of:'
+                    . ' `%2$s` implementations'
+                    . ', `class-string<%2$s>`'
+                    . ', `class-string<object&%3$s>`'
+                    . ', `%3$s`'
+                    . '; "%4$s" given',
+                    $delegatedServiceName,
+                    DelegatorFactoryInterface::class,
+                    'callable(ContainerInterface,string,callable():mixed,array|null):mixed',
+                    get_debug_type($delegator),
+                ));
+            }
+        }
+    }
+
+    private function assertIsValidFactoryConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('factories');
+        }
+
+        /**
+         * @var mixed $factory
+         * @var array-key $serviceName
+         */
+        foreach ($configuration as $serviceName => $factory) {
+            if (! is_string($serviceName)) {
+                throw InvalidServiceManagerConfigurationException::fromNonMapConfiguration('factories');
+            }
+
+            if ($factory instanceof FactoryInterface) {
+                continue;
+            }
+
+            if (
+                is_string($factory)
+                && class_exists($factory)
+                && method_exists($factory, '__invoke')
+            ) {
+                // assume class-string providing a class which implements `__invoke` also implements expected signatures
+                continue;
+            }
+
+            if (is_callable($factory)) {
+                // assume the callable implements expected signatures
+                continue;
+            }
+
+            throw new InvalidServiceManagerConfigurationException(sprintf(
+                'Provided `factories.%1$s` configuration has to represent an array of any of:'
+                . ' `%2$s` implementations'
+                . ', `class-string<%2$s>`'
+                . ', `class-string<object&%3$s>`'
+                . ', `%3$s`'
+                . '; "%4$s" given ',
+                $serviceName,
+                FactoryInterface::class,
+                'callable(ContainerInterface,string,array|null):mixed',
+                get_debug_type($factory),
+            ));
+        }
+    }
+
+    private function assertIsValidAbstractFactoriesConfiguration(mixed $configuration): void
+    {
+        if (! is_array($configuration)) {
+            throw InvalidServiceManagerConfigurationException::fromNonArrayConfiguration(
+                'abstract_factories',
+                $configuration
+            );
+        }
+
+        /** @var mixed $abstractFactory */
+        foreach ($configuration as $abstractFactory) {
+            if ($abstractFactory instanceof AbstractFactoryInterface) {
+                continue;
+            }
+
+            if (
+                is_string($abstractFactory)
+                && class_exists($abstractFactory)
+                && in_array(AbstractFactoryInterface::class, class_implements($abstractFactory), true)
+            ) {
+                continue;
+            }
+
+            throw new InvalidServiceManagerConfigurationException(sprintf(
+                'Configuration `abstract_factories` has to provide an array of abstract factories implementing `%1$s`.'
+                . ' Both `class-string<%1$s>` and instances of `%1$s` are allowed; "%2$s" given',
+                AbstractFactoryInterface::class,
+                get_debug_type($abstractFactory),
+            ));
+        }
+    }
+}

--- a/src/ConfigValidatorInterface.php
+++ b/src/ConfigValidatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\ServiceManager;
+
+use Laminas\ServiceManager\Exception\InvalidArgumentException;
+
+/**
+ * Due to limitations, it is not possible to verify if callables or factories signatures are correct.
+ * This validation will assume that callables and factories do return the appropriate types and that
+ * the configuration structure matches declaration.
+ *
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ */
+interface ConfigValidatorInterface
+{
+    /**
+     * @psalm-assert ServiceManagerConfiguration $config
+     * @throws InvalidArgumentException If configuration does not match expectations.
+     */
+    public function assertIsValidConfiguration(array $config): void;
+
+    /**
+     * @psalm-assert-if-true ServiceManagerConfiguration $config
+     */
+    public function isValidConfiguration(array $config): bool;
+}

--- a/src/Exception/InvalidServiceManagerConfigurationException.php
+++ b/src/Exception/InvalidServiceManagerConfigurationException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\ServiceManager\Exception;
+
+use function get_debug_type;
+use function sprintf;
+
+final class InvalidServiceManagerConfigurationException extends InvalidArgumentException
+{
+    /**
+     * @internal
+     *
+     * @param non-empty-string $identifier
+     */
+    public static function fromNonArrayConfiguration(string $identifier, mixed $value): self
+    {
+        return new self(sprintf(
+            'Configuration `%s` is expected to represent an array structure; "%s" given',
+            $identifier,
+            get_debug_type($value)
+        ));
+    }
+
+    /**
+     * @internal
+     *
+     * @param non-empty-string $identifier
+     */
+    public static function fromNonMapConfiguration(string $identifier): self
+    {
+        return new self(sprintf(
+            'Configuration `%s` is expected to represent an array map',
+            $identifier
+        ));
+    }
+}

--- a/test/ConfigValidatorTest.php
+++ b/test/ConfigValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ServiceManager;
+
+use Laminas\ServiceManager\ConfigValidator;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use LaminasTest\ServiceManager\TestAsset\SimpleAbstractFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use stdClass;
+
+final class ConfigValidatorTest extends TestCase
+{
+    private ConfigValidator $validator;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = new ConfigValidator();
+    }
+
+    public function testWillValidateValidConfiguration(): void
+    {
+        $config = [
+            'services'           => [
+                'config' => ['foo' => 'bar'],
+            ],
+            'factories'          => [
+                stdClass::class => InvokableFactory::class,
+            ],
+            'delegators'         => [
+                stdClass::class => [
+                    static function (ContainerInterface $container, string $name, callable $callback): object {
+                        $instance = $callback();
+                        self::assertInstanceOf(stdClass::class, $instance);
+                        $instance->foo = 'bar';
+
+                        return $instance;
+                    },
+                ],
+            ],
+            'shared'             => [
+                'config'        => true,
+                stdClass::class => true,
+            ],
+            'aliases'            => [
+                'Aliased' => stdClass::class,
+            ],
+            'shared_by_default'  => false,
+            'abstract_factories' => [
+                new SimpleAbstractFactory(),
+            ],
+            'initializers'       => [
+                static function (ContainerInterface $container, mixed $instance): void {
+                    if (! $instance instanceof stdClass) {
+                        return;
+                    }
+
+                    $instance->bar = 'baz';
+                },
+            ],
+        ];
+
+        $this->validator->assertIsValidConfiguration($config);
+        self::assertTrue($this->validator->isValidConfiguration($config));
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Starting with v4.0.0, the `ServiceManager` itself will not validate anymore as it provides psalm array-shape type for configuration values.

As per existing projects, the `ServiceManager` is usually configured somehow like these examples:

```php
$smConfig = $configuration['service_manager'] ?? [];
$smConfig = new ServiceManagerConfig($smConfig);

$serviceManager = new ServiceManager();
$smConfig->configureServiceManager($serviceManager);
```

```php
$config = require __DIR__ . '/config.php';

$dependencies                       = $config['dependencies'];
$dependencies['services']['config'] = $config;

$serviceManager = new ServiceManager($dependencies);
```

The first example does use deprecated `Config` instance which just verified that pre-defined array keys are provided.
The second example does not verify anything and assumes the config to be correct.

Both cases do either need a psalm-baseline entry or a `psalm-suppress` once migrated to SM v4.0.0 (at least the second example already needs that as it uses the `ServiceManager#__construct` which is already properly typed.

Closes #131 

---

So every pluginmanager providing component (such as `laminas-cache`, `laminas-form`, etc. - I've listed some more in the [TSC meeting](https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2023--1-09-TSC-Minutes.md#psr-11-v2)) would also need either [a baseline entry or suppression](https://github.com/laminas/laminas-form/blob/e49893f4a3f1fbe3e70238b119366b6913cc83ef/src/FormElementManagerFactory.php#L51) due to the fact that there is no current way to verify that configuration matches expectations.

To avoid that, we could in fact use a runtime configuration validator which is provided by this PR.

----

I have not yet a clue on how to effectively use it, as I would actually prefer to only validate prior configuration caching so that not every request has to validate the same valid/invalid config over and over again. I've created this PR as a draft so that we can find a way of how to effectively use such a validator. In mezzio projects, having this as some kind of `PostProcessor` for `config-aggregator` would work but that won't work for i.e. [laminas-form](https://github.com/laminas/laminas-form/blob/e49893f4a3f1fbe3e70238b119366b6913cc83ef/src/FormElementManagerFactory.php#L51)

Would love to get some help here.