### PR TITLE
Backport: Duplicate `ConfigInterface` psalm types in `ServiceManager`

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -53,20 +53,42 @@ use const E_USER_DEPRECATED;
  *
  * @see ConfigInterface
  *
- * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
- * @psalm-import-type AbstractFactoriesConfigurationType from ConfigInterface
- * @psalm-import-type DelegatorsConfigurationType from ConfigInterface
- * @psalm-import-type FactoriesConfigurationType from ConfigInterface
- * @psalm-import-type InitializersConfigurationType from ConfigInterface
- * @psalm-import-type LazyServicesConfigurationType from ConfigInterface
+ * @psalm-type AbstractFactoriesConfiguration = array<
+ *      array-key,
+ *      (class-string<Factory\AbstractFactoryInterface>|Factory\AbstractFactoryInterface)
+ * >
+ * @psalm-type DelegatorsConfiguration = array<
+ *      string,
+ *      array<
+ *          array-key,
+ *          (class-string<Factory\DelegatorFactoryInterface>|Factory\DelegatorFactoryInterface)
+ *          |callable(ContainerInterface,string,callable():object,array<mixed>|null):object
+ *      >
+ * >
+ * @psalm-type FactoriesConfiguration = array<
+ *      string,
+ *      (class-string<Factory\FactoryInterface>|Factory\FactoryInterface)
+ *      |callable(ContainerInterface,?string,?array<mixed>|null):object
+ * >
+ * @psalm-type InitializersConfiguration = array<
+ *      array-key,
+ *      (class-string<Initializer\InitializerInterface>|Initializer\InitializerInterface)
+ *      |callable(ContainerInterface,object):void
+ * >
+ * @psalm-type LazyServicesConfiguration = array{
+ *      class_map?:array<string,class-string>,
+ *      proxies_namespace?:non-empty-string,
+ *      proxies_target_dir?:non-empty-string,
+ *      write_proxy_files?:bool
+ * }
  * @psalm-type ServiceManagerConfiguration = array{
- *     abstract_factories?: AbstractFactoriesConfigurationType,
+ *     abstract_factories?: AbstractFactoriesConfiguration,
  *     aliases?: array<string,string>,
- *     delegators?: DelegatorsConfigurationType,
- *     factories?: FactoriesConfigurationType,
- *     initializers?: InitializersConfigurationType,
+ *     delegators?: DelegatorsConfiguration,
+ *     factories?: FactoriesConfiguration,
+ *     initializers?: InitializersConfiguration,
  *     invokables?: array<string,string>,
- *     lazy_services?: LazyServicesConfigurationType,
+ *     lazy_services?: LazyServicesConfiguration,
  *     services?: array<string,object|array>,
  *     shared?:array<string,bool>,
  *     shared_by_default?:bool,
@@ -99,7 +121,7 @@ class ServiceManager implements ServiceLocatorInterface
 
     /**
      * @var string[][]|Factory\DelegatorFactoryInterface[][]
-     * @psalm-var DelegatorsConfigurationType
+     * @psalm-var DelegatorsConfiguration
      */
     protected $delegators = [];
 
@@ -107,19 +129,19 @@ class ServiceManager implements ServiceLocatorInterface
      * A list of factories (either as string name or callable)
      *
      * @var string[]|callable[]
-     * @psalm-var FactoriesConfigurationType
+     * @psalm-var FactoriesConfiguration
      */
     protected $factories = [];
 
     /**
      * @var Initializer\InitializerInterface[]|callable[]
-     * @psalm-var InitializersConfigurationType
+     * @psalm-var InitializersConfiguration
      */
     protected $initializers = [];
 
     /**
      * @var array
-     * @psalm-var LazyServicesConfigurationType
+     * @psalm-var LazyServicesConfiguration
      */
     protected $lazyServices = [];
 
@@ -512,7 +534,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Instantiate initializers for to avoid checks during service construction.
      *
-     * @psalm-param InitializersConfigurationType $initializers
+     * @psalm-param InitializersConfiguration $initializers
      */
     private function resolveInitializers(array $initializers): void
     {
@@ -689,8 +711,8 @@ class ServiceManager implements ServiceLocatorInterface
      * It works with strings and class instances.
      * It's not possible to de-duple anonymous functions
      *
-     * @psalm-param DelegatorsConfigurationType $config
-     * @psalm-return DelegatorsConfigurationType
+     * @psalm-param DelegatorsConfiguration $config
+     * @psalm-return DelegatorsConfiguration
      */
     private function mergeDelegators(array $config): array
     {
@@ -745,7 +767,7 @@ class ServiceManager implements ServiceLocatorInterface
      * a given service name we do not have a service instance
      * in the cache OR override is explicitly allowed.
      *
-     * @psalm-param ServiceManagerConfigurationType $config
+     * @psalm-param ServiceManagerConfiguration $config
      * @throws ContainerModificationsNotAllowedException If any
      *     service key is invalid.
      */


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Due to the fact that `ConfigInterface` will get removed in v4, moving psalm-types already in v3 to `ServiceManager` will help projects to already start migration.
