### PR TITLE
Mark `Config` and `ConfigInterface` as deprecated

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/AbstractFactory/ConfigAbstractFactory.php">
     <InvalidStringClass>
       <code>new $requestedName(...$arguments)</code>
@@ -59,6 +59,9 @@
       <code>$config</code>
       <code>$config</code>
     </ArgumentTypeCoercion>
+    <DeprecatedInterface>
+      <code>null|ConfigInterface|ContainerInterface</code>
+    </DeprecatedInterface>
     <ImplementedParamTypeMismatch>
       <code>$service</code>
     </ImplementedParamTypeMismatch>
@@ -79,6 +82,9 @@
     </UnusedPsalmSuppress>
   </file>
   <file src="src/Config.php">
+    <DeprecatedInterface>
+      <code>Config</code>
+    </DeprecatedInterface>
     <LessSpecificReturnStatement>
       <code>ArrayUtils::merge($a, $b)</code>
     </LessSpecificReturnStatement>
@@ -510,6 +516,9 @@
     </UnusedClosureParam>
   </file>
   <file src="test/ConfigTest.php">
+    <DeprecatedClass>
+      <code>new Config($config)</code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code>$configInstance</code>
       <code>$configuration</code>

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,8 @@ use function array_keys;
  * These features are advanced, and not typically used. If you wish to use them,
  * you will need to require the laminas-stdlib package in your application.
  *
+ * @deprecated Class will be removed as of v4.0
+ *
  * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
  */
 class Config implements ConfigInterface

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -8,6 +8,8 @@ use ArrayAccess;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @deprecated Interface will be removed as of v4.0
+ *
  * @see ContainerInterface
  * @see ArrayAccess
  *


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Marking the `ConfigInterface` and the `Config` object. They do not provide any useful additions besides the fact that it holds a configuration which could also get passed as an array. In most if not all use-cases, the config is passed as an array to the `ServiceManager` anyways and thus, having an array should suffice as well.
