### PR TITLE
Narrow array type for `services` in ServiceManager configuration

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -89,7 +89,7 @@ use const E_USER_DEPRECATED;
  *     initializers?: InitializersConfiguration,
  *     invokables?: array<string,string>,
  *     lazy_services?: LazyServicesConfiguration,
- *     services?: array<string,object|array>,
+ *     services?: array<string,object|array<mixed>>,
  *     shared?:array<string,bool>,
  *     shared_by_default?:bool,
  *     ...


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR adds a more specific array shape for the `services` key in `ServiceManagerConfiguration`.

fixes #212