### PR TITLE
Fix return type to generic in ReflectionBasedAbstractFactory

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -19,40 +19,27 @@
   <file src="src/AbstractFactory/ReflectionBasedAbstractFactory.php">
     <ArgumentTypeCoercion>
       <code>$requestedName</code>
+      <code>$requestedName</code>
     </ArgumentTypeCoercion>
-    <LessSpecificReturnStatement>
+    <InvalidStringClass>
       <code>new $requestedName()</code>
       <code>new $requestedName()</code>
       <code>new $requestedName(...$parameters)</code>
-    </LessSpecificReturnStatement>
+    </InvalidStringClass>
     <MissingClosureReturnType>
       <code>function (ReflectionParameter $parameter) use ($container, $requestedName) {</code>
     </MissingClosureReturnType>
-    <MissingParamType>
-      <code>$requestedName</code>
-    </MissingParamType>
-    <MixedArgument>
-      <code>$requestedName</code>
-      <code>$requestedName</code>
-      <code>$requestedName</code>
-    </MixedArgument>
     <MixedMethodCall>
       <code>new $requestedName()</code>
       <code>new $requestedName()</code>
       <code>new $requestedName(...$parameters)</code>
     </MixedMethodCall>
-    <MoreSpecificReturnType>
-      <code>DispatchableInterface</code>
-    </MoreSpecificReturnType>
     <PossiblyNullArgument>
       <code>$type</code>
     </PossiblyNullArgument>
     <RedundantCondition>
       <code>is_string($type)</code>
     </RedundantCondition>
-    <UndefinedDocblockClass>
-      <code>DispatchableInterface</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/AbstractFactoryInterface.php">
     <PossiblyUnusedMethod>
@@ -350,16 +337,6 @@
     </InvalidArgument>
   </file>
   <file src="test/AbstractFactory/ReflectionBasedAbstractFactoryTest.php">
-    <DocblockTypeContradiction>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-      <code>assertInstanceOf</code>
-    </DocblockTypeContradiction>
     <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>

--- a/src/AbstractFactory/ReflectionBasedAbstractFactory.php
+++ b/src/AbstractFactory/ReflectionBasedAbstractFactory.php
@@ -106,7 +106,9 @@ class ReflectionBasedAbstractFactory implements AbstractFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @return DispatchableInterface
+     * @param class-string<T>|string $requestedName
+     * @return ($requestedName is class-string<T> ? T : object)
+     * @template T of object
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

`ReflectionBasedAbstractFactory` has invalid return type when invoking. This PR adds also generics to return type, because it always create class directly from `$requestedName`
