### PR TITLE
Allow varexporter v0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "brick/varexporter": "^0.3.8 || ^0.4.0",
+        "brick/varexporter": "^0.3.8 || ^0.4.0 || ^0.5.0",
         "laminas/laminas-stdlib": "^3.17",
         "psr/container": "^1.1 || ^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84fac30ea170d4ad039fb66654643de1",
+    "content-hash": "1a4bc93b1457b503c327cdfbbe234c8f",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -5559,5 +5559,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Support for brick/varexporter v0.5.0 to turn supports nikic/PHP-Parser v5 and enabling upgrades to PHPUnit 11 in downstream projects.