### PR TITLE
fix: Fix LazyServiceFactory to handle exception in constructor

### DIFF
--- a/src/Proxy/LazyServiceFactory.php
+++ b/src/Proxy/LazyServiceFactory.php
@@ -10,6 +10,7 @@ use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;
 use Psr\Container\ContainerInterface;
+use Throwable;
 
 use function sprintf;
 
@@ -42,8 +43,14 @@ final class LazyServiceFactory implements DelegatorFactoryInterface
     ): VirtualProxyInterface {
         if (isset($this->servicesMap[$name])) {
             $initializer = static function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($callback): bool {
+                $initializer = $proxy->getProxyInitializer();
                 $proxy->setProxyInitializer(null);
-                $wrappedInstance = $callback();
+                try {
+                    $wrappedInstance = $callback();
+                } catch (Throwable $e) {
+                    $proxy->setProxyInitializer($initializer);
+                    throw $e;
+                }
 
                 return true;
             };

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -15,6 +15,7 @@ use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 #[CoversClass(LazyServiceFactory::class)]
 final class LazyServiceFactoryTest extends TestCase
@@ -93,5 +94,53 @@ final class LazyServiceFactoryTest extends TestCase
         $result = $this->factory->__invoke($this->container, 'fooService', $callback->callback(...));
 
         self::assertSame($expectedService, $result, 'service created not match the expected');
+    }
+
+    public function testHandlesExceptionInInitializer(): void
+    {
+        $callback = function (): void {
+            throw new RuntimeException('Test exception');
+        };
+
+        $proxy       = $this->createMock(LazyLoadingInterface::class);
+        $initializer = static fn(): bool => true;
+
+        $proxy->expects(self::once())
+            ->method('getProxyInitializer')
+            ->willReturn($initializer);
+
+        $proxy
+            ->expects(self::exactly(2))
+            ->method('setProxyInitializer')
+            ->willReturnMap(
+                [
+                    [null],
+                    [$initializer],
+                ]
+            );
+
+        $expectedService = $this->createMock(VirtualProxyInterface::class);
+
+        $this->proxyFactory
+            ->expects(self::once())
+            ->method('createProxy')
+            ->willReturnCallback(
+                /** @psalm-suppress UnusedVariable */
+                static function (string $className, callable $initializer) use ($expectedService, $proxy): MockObject {
+                    self::assertEquals('FooClass', $className);
+
+                    try {
+                        $wrappedInstance = null;
+                        $initializer($wrappedInstance, $proxy);
+                        self::fail('Expected exception was not thrown');
+                    } catch (RuntimeException) {
+                    }
+
+                    return $expectedService;
+                }
+            );
+
+        $result = $this->factory->__invoke($this->container, 'fooService', $callback);
+        self::assertSame($expectedService, $result);
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR fixes a bug where exceptions thrown during lazy service initialization would leave the proxy in an invalid state. The fix ensures that the original initializer is restored when an exception occurs, allowing subsequent initialization attempts to work correctly.
Added tests to verify the behavior.

p.s. thanks to @vdmorozov, he found the issue