### PR TITLE
fix: LazyServiceFactory does not reset initializer in proxy class when building dependency fails

### DIFF
--- a/src/Proxy/LazyServiceFactory.php
+++ b/src/Proxy/LazyServiceFactory.php
@@ -42,8 +42,8 @@ final class LazyServiceFactory implements DelegatorFactoryInterface
     ): VirtualProxyInterface {
         if (isset($this->servicesMap[$name])) {
             $initializer = static function (&$wrappedInstance, LazyLoadingInterface $proxy) use ($callback): bool {
-                $proxy->setProxyInitializer(null);
                 $wrappedInstance = $callback();
+                $proxy->setProxyInitializer(null);
 
                 return true;
             };

--- a/test/Proxy/LazyServiceFactoryTest.php
+++ b/test/Proxy/LazyServiceFactoryTest.php
@@ -114,6 +114,7 @@ final class LazyServiceFactoryTest extends TestCase
             ->expects(self::once())
             ->method('createProxy')
             ->willReturnCallback(
+                /** @psalm-suppress UnusedVariable */
                 static function (string $className, callable $initializer) use ($expectedService, $proxy): MockObject {
                     $wrappedInstance = null;
                     $initializer($wrappedInstance, $proxy);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes a bug where an exception thrown during lazy service initialization would leave the proxy in an invalid state. The fix ensures that the original initializer isn't reset when an exception occurs, allowing subsequent initialization attempts to work correctly.

Added tests to verify the behavior.