### PR TITLE
Remove duplicate delgators for all services

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -705,8 +705,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         foreach ($config as $key => $delegators) {
             if (! array_key_exists($key, $this->delegators)) {
-                $this->delegators[$key] = $delegators;
-                continue;
+                $this->delegators[$key] = [];
             }
 
             foreach ($delegators as $delegator) {

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -385,8 +385,7 @@ final class ServiceManagerTest extends TestCase
         ];
         $serviceManager = new ServiceManager($dependencies);
         $property       = new ReflectionProperty(ServiceManager::class, "delegators");
-        $property->setAccessible(true);
-        $delegators = $property->getValue($serviceManager);
+        $delegators     = $property->getValue($serviceManager);
         self::assertSame(
             [
                 DateTime::class => [

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\ServiceManager;
 
 use DateTime;
+use Laminas\ContainerConfigTest\TestAsset\DelegatorFactory;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
@@ -370,6 +371,30 @@ final class ServiceManagerTest extends TestCase
         $serviceManager = new SimpleServiceManager($config);
 
         self::assertEquals(stdClass::class, $serviceManager->get(stdClass::class)::class);
+    }
+
+    public function testDuplicateDelegatorsAreRemoved(): void
+    {
+        $dependencies   = [
+            'delegators' => [
+                DateTime::class => [
+                    DelegatorFactory::class,
+                    DelegatorFactory::class,
+                ],
+            ],
+        ];
+        $serviceManager = new ServiceManager($dependencies);
+        $property       = new ReflectionProperty(ServiceManager::class, "delegators");
+        $property->setAccessible(true);
+        $delegators = $property->getValue($serviceManager);
+        self::assertSame(
+            [
+                DateTime::class => [
+                    DelegatorFactory::class,
+                ],
+            ],
+            $delegators
+        );
     }
 
     public function testResolvedAliasFromAbstractFactory(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

[`ServiceManager::mergeDelegators()` documentation](https://github.com/laminas/laminas-servicemanager/blob/4.4.x/src/ServiceManager.php#L697-L699) says that it merges delegators avoiding multiple same delegators for the same service. However, from experimenting with it, duplicates **are** allowed. So, I've created this small patch to ensure that duplicates are removed, along with a covering test for it to verify the change.
