### PR TITLE
Backport remove duplicate delegators fix to 3.22.x

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -718,8 +718,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         foreach ($config as $key => $delegators) {
             if (! array_key_exists($key, $this->delegators)) {
-                $this->delegators[$key] = $delegators;
-                continue;
+                $this->delegators[$key] = [];
             }
 
             foreach ($delegators as $delegator) {

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -410,8 +410,7 @@ final class ServiceManagerTest extends TestCase
         ];
         $serviceManager = new ServiceManager($dependencies);
         $property       = new ReflectionProperty(ServiceManager::class, "delegators");
-        $property->setAccessible(true);
-        $delegators = $property->getValue($serviceManager);
+        $delegators     = $property->getValue($serviceManager);
         self::assertSame(
             [
                 DateTime::class => [

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\ServiceManager;
 
 use DateTime;
+use Laminas\ContainerConfigTest\TestAsset\DelegatorFactory;
 use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -15,6 +16,7 @@ use LaminasTest\ServiceManager\TestAsset\InvokableObject;
 use LaminasTest\ServiceManager\TestAsset\SimpleServiceManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use ReflectionProperty;
 use stdClass;
 
 /**
@@ -394,6 +396,30 @@ final class ServiceManagerTest extends TestCase
         $serviceManager = new SimpleServiceManager($config);
 
         self::assertEquals(stdClass::class, $serviceManager->get(stdClass::class)::class);
+    }
+
+    public function testDuplicateDelegatorsAreRemoved(): void
+    {
+        $dependencies   = [
+            'delegators' => [
+                DateTime::class => [
+                    DelegatorFactory::class,
+                    DelegatorFactory::class,
+                ],
+            ],
+        ];
+        $serviceManager = new ServiceManager($dependencies);
+        $property       = new ReflectionProperty(ServiceManager::class, "delegators");
+        $property->setAccessible(true);
+        $delegators = $property->getValue($serviceManager);
+        self::assertSame(
+            [
+                DateTime::class => [
+                    DelegatorFactory::class,
+                ],
+            ],
+            $delegators
+        );
     }
 
     public function testResolvedAliasFromAbstractFactory(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This backports #251 to the 3.22.x branch.
