### PR TITLE
Do not remove delegators on service creation

### DIFF
--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -601,9 +601,9 @@ class ServiceManager implements ServiceLocatorInterface
         $resolvedDelegators = [];
         foreach ($this->delegators[$name] as $index => $delegatorFactory) {
             /** @psalm-suppress ArgumentTypeCoercion https://github.com/vimeo/psalm/issues/9680 */
-            $delegatorFactory                = $this->resolveDelegatorFactory($delegatorFactory);
-            $this->delegators[$name][$index] = $delegatorFactory;
-            $creationCallback                =
+            $delegatorFactory           = $this->resolveDelegatorFactory($delegatorFactory);
+            $resolvedDelegators[$index] = $delegatorFactory;
+            $creationCallback           =
                 static fn(): mixed => $delegatorFactory($initialCreationContext, $name, $creationCallback, $options);
         }
 

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\ServiceManager;
 
 use DateTime;
+use Laminas\ContainerConfigTest\TestAsset\Delegator;
 use Laminas\ContainerConfigTest\TestAsset\DelegatorFactory;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -394,6 +395,30 @@ final class ServiceManagerTest extends TestCase
             ],
             $delegators
         );
+    }
+
+    public function testDelegatorsAreUsedOnRepeatedCreate(): void
+    {
+        $dependencies   = [
+            'delegators' => [
+                DateTime::class => [
+                    DelegatorFactory::class,
+                    DelegatorFactory::class,
+                ],
+            ],
+            'invokables' => [
+                DateTime::class => DateTime::class,
+            ],
+        ];
+        $serviceManager = new ServiceManager($dependencies);
+
+        $first  = $serviceManager->build(DateTime::class);
+        $second = $serviceManager->build(DateTime::class);
+
+        /** @psalm-suppress DocblockTypeContradiction*/
+        self::assertInstanceOf(Delegator::class, $first);
+        /** @psalm-suppress DocblockTypeContradiction*/
+        self::assertInstanceOf(Delegator::class, $second);
     }
 
     public function testResolvedAliasFromAbstractFactory(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I have encountered bug in application which occurs when two requests triggers creation of same service at same time(app is running on swoole so ServiceManager is shared across requests).  In this case both requests call $serviceManager->get(Service), which leads to two doCreate calls. First call removes delegators and then second one creates service without them. Problem is that the result from the second call(without delegators) is stored in ServiceManager->services.
